### PR TITLE
Introduce namespace to environments

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -108,7 +108,7 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace()
+		c.Namespace, err = namespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -71,7 +71,7 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace()
+		c.Namespace, err = namespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -69,7 +69,7 @@ var diffCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace()
+		c.Namespace, err = namespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -82,7 +82,7 @@ var initCmd = &cobra.Command{
 			}
 		}
 
-		c, err := kubecfg.NewInitCmd(appRoot, specFlag, currClusterURI)
+		c, err := kubecfg.NewInitCmd(appRoot, specFlag, currClusterURI, &currCtx.Namespace)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,7 @@ var RootCmd = &cobra.Command{
 
 // clientConfig.Namespace() is broken in client-go 3.0:
 // namespace in config erroneously overrides explicit --namespace
-func defaultNamespace() (string, error) {
+func namespace() (string, error) {
 	if overrides.Context.Namespace != "" {
 		return overrides.Context.Namespace, nil
 	}
@@ -295,7 +295,8 @@ func parseEnvCmd(cmd *cobra.Command, args []string) (*envSpec, error) {
 //
 // If the environment URI the user is attempting to deploy to is not the current
 // kubeconfig context, we must manually override the client-go --cluster flag
-// to ensure we are deploying to the correct cluster.
+// to ensure we are deploying to the correct cluster. The same logic applies
+// for overwriting the --namespace flag.
 func overrideCluster(envName string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -333,6 +334,10 @@ func overrideCluster(envName string) error {
 		clusterName := clusterURIs[env.URI]
 		log.Debugf("Overwriting --cluster flag with '%s'", clusterName)
 		overrides.Context.Cluster = clusterName
+		if len(env.Namespace) != 0 {
+			log.Debugf("Overwriting --namespace flag with '%s'", env.Namespace)
+			overrides.Context.Namespace = env.Namespace
+		}
 		return nil
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -84,7 +84,7 @@ local configuration. Accepts JSON, YAML, or Jsonnet.`,
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace()
+		c.Namespace, err = namespace()
 		if err != nil {
 			return err
 		}

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -35,6 +35,7 @@ const (
 )
 
 var mockAPIServerURI = "http://google.com"
+var mockNamespace = "some-namespace"
 
 func mockEnvironments(t *testing.T, appName string) *manager {
 	spec, err := parseClusterSpec(fmt.Sprintf("file:%s", blankSwagger), testFS)
@@ -43,7 +44,7 @@ func mockEnvironments(t *testing.T, appName string) *manager {
 	}
 
 	appPath := AbsPath(appName)
-	m, err := initManager(appPath, spec, &mockAPIServerURI, testFS)
+	m, err := initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err != nil {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
@@ -53,9 +54,9 @@ func mockEnvironments(t *testing.T, appName string) *manager {
 		envPath := appendToAbsPath(m.environmentsPath, env)
 
 		specPath := appendToAbsPath(envPath, mockSpecJSON)
-		specData, err := generateSpecData(mockSpecJSONURI)
+		specData, err := generateSpecData(mockSpecJSONURI, mockNamespace)
 		if err != nil {
-			t.Fatalf("Expected to marshal:\n%s\n, but failed", mockSpecJSONURI)
+			t.Fatalf("Expected to marshal:\nuri: %s\nnamespace: %s\n, but failed", mockSpecJSONURI, mockNamespace)
 		}
 		err = afero.WriteFile(testFS, string(specPath), specData, os.ModePerm)
 		if err != nil {
@@ -136,7 +137,8 @@ func TestSetEnvironment(t *testing.T) {
 
 	setName := "new-env"
 	setURI := "http://example.com"
-	set := Environment{Name: setName, URI: setURI}
+	setNamespace := "some-namespace"
+	set := Environment{Name: setName, URI: setURI, Namespace: setNamespace}
 
 	// Test updating an environment that doesn't exist
 	err := m.SetEnvironment("notexists", &set)
@@ -178,6 +180,9 @@ func TestSetEnvironment(t *testing.T) {
 	}
 	if envSpec.URI != set.URI {
 		t.Fatalf("Expected set URI to be \"%s\", got:\n  %s", set.URI, envSpec.URI)
+	}
+	if envSpec.Namespace != set.Namespace {
+		t.Fatalf("Expected set Namespace to be \"%s\", got:\n  %s", set.Namespace, envSpec.Namespace)
 	}
 }
 

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -44,7 +44,7 @@ type Manager interface {
 	ComponentPaths() (AbsPaths, error)
 	CreateComponent(name string, text string, templateType prototype.TemplateType) error
 	LibPaths(envName string) (libPath, envLibPath, envComponentPath AbsPath)
-	CreateEnvironment(name, uri string, spec ClusterSpec) error
+	CreateEnvironment(name, uri, namespace string, spec ClusterSpec) error
 	DeleteEnvironment(name string) error
 	GetEnvironments() ([]*Environment, error)
 	GetEnvironment(name string) (*Environment, error)
@@ -68,8 +68,8 @@ func Find(path AbsPath) (Manager, error) {
 // Init will retrieve a cluster API specification, generate a
 // capabilities-compliant version of ksonnet-lib, and then generate the
 // directory tree for an application.
-func Init(rootPath AbsPath, spec ClusterSpec, serverURI *string) (Manager, error) {
-	return initManager(rootPath, spec, serverURI, appFS)
+func Init(rootPath AbsPath, spec ClusterSpec, serverURI, namespace *string) (Manager, error) {
+	return initManager(rootPath, spec, serverURI, namespace, appFS)
 }
 
 // ClusterSpec represents the API supported by some cluster. There are several

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -80,7 +80,7 @@ func findManager(abs AbsPath, appFS afero.Fs) (*manager, error) {
 	}
 }
 
-func initManager(rootPath AbsPath, spec ClusterSpec, serverURI *string, appFS afero.Fs) (*manager, error) {
+func initManager(rootPath AbsPath, spec ClusterSpec, serverURI, namespace *string, appFS afero.Fs) (*manager, error) {
 	m := newManager(rootPath, appFS)
 
 	// Generate the program text for ksonnet-lib.
@@ -101,9 +101,8 @@ func initManager(rootPath AbsPath, spec ClusterSpec, serverURI *string, appFS af
 	}
 
 	// Initialize environment, and cache specification data.
-	// TODO the URI for the default environment needs to be generated from KUBECONFIG
 	if serverURI != nil {
-		err := m.createEnvironment(defaultEnvName, *serverURI, extensionsLibData, k8sLibData, specData)
+		err := m.createEnvironment(defaultEnvName, *serverURI, *namespace, extensionsLibData, k8sLibData, specData)
 		if err != nil {
 			return nil, err
 		}

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -60,7 +60,7 @@ func TestInitSuccess(t *testing.T) {
 	}
 
 	appPath := AbsPath("/fromEmptySwagger")
-	_, err = initManager(appPath, spec, &mockAPIServerURI, testFS)
+	_, err = initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err != nil {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestFindSuccess(t *testing.T) {
 	}
 
 	appPath := AbsPath("/findSuccess")
-	_, err = initManager(appPath, spec, &mockAPIServerURI, testFS)
+	_, err = initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err != nil {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestComponentPaths(t *testing.T) {
 	}
 
 	appPath := AbsPath("/componentPaths")
-	m, err := initManager(appPath, spec, &mockAPIServerURI, testFS)
+	m, err := initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err != nil {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
@@ -251,13 +251,13 @@ func TestDoubleNewFailure(t *testing.T) {
 
 	appPath := AbsPath("/doubleNew")
 
-	_, err = initManager(appPath, spec, &mockAPIServerURI, testFS)
+	_, err = initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err != nil {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
 
 	targetErr := fmt.Sprintf("Could not create app; directory '%s' already exists", appPath)
-	_, err = initManager(appPath, spec, &mockAPIServerURI, testFS)
+	_, err = initManager(appPath, spec, &mockAPIServerURI, &mockNamespace, testFS)
 	if err == nil || err.Error() != targetErr {
 		t.Fatalf("Expected to fail to create app with message '%s', got '%s'", targetErr, err.Error())
 	}

--- a/pkg/kubecfg/apply.go
+++ b/pkg/kubecfg/apply.go
@@ -41,9 +41,9 @@ const (
 
 // ApplyCmd represents the apply subcommand
 type ApplyCmd struct {
-	ClientPool       dynamic.ClientPool
-	Discovery        discovery.DiscoveryInterface
-	DefaultNamespace string
+	ClientPool dynamic.ClientPool
+	Discovery  discovery.DiscoveryInterface
+	Namespace  string
 
 	Create bool
 	GcTag  string
@@ -69,7 +69,7 @@ func (c ApplyCmd) Run(apiObjects []*unstructured.Unstructured, wd metadata.AbsPa
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Updating ", desc, dryRunText)
 
-		rc, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		rc, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -31,9 +31,9 @@ import (
 
 // DeleteCmd represents the delete subcommand
 type DeleteCmd struct {
-	ClientPool       dynamic.ClientPool
-	Discovery        discovery.DiscoveryInterface
-	DefaultNamespace string
+	ClientPool dynamic.ClientPool
+	Discovery  discovery.DiscoveryInterface
+	Namespace  string
 
 	GracePeriod int64
 }
@@ -64,7 +64,7 @@ func (c DeleteCmd) Run(apiObjects []*unstructured.Unstructured) error {
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Deleting ", desc)
 
-		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -37,9 +37,9 @@ var ErrDiffFound = fmt.Errorf("Differences found.")
 
 // DiffCmd represents the diff subcommand
 type DiffCmd struct {
-	ClientPool       dynamic.ClientPool
-	Discovery        discovery.DiscoveryInterface
-	DefaultNamespace string
+	ClientPool dynamic.ClientPool
+	Discovery  discovery.DiscoveryInterface
+	Namespace  string
 
 	DiffStrategy string
 }
@@ -52,7 +52,7 @@ func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) err
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Debugf("Fetching ", desc)
 
-		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/init.go
+++ b/pkg/kubecfg/init.go
@@ -6,9 +6,10 @@ type InitCmd struct {
 	rootPath  metadata.AbsPath
 	spec      metadata.ClusterSpec
 	serverURI *string
+	namespace *string
 }
 
-func NewInitCmd(rootPath metadata.AbsPath, specFlag string, serverURI *string) (*InitCmd, error) {
+func NewInitCmd(rootPath metadata.AbsPath, specFlag string, serverURI, namespace *string) (*InitCmd, error) {
 	// NOTE: We're taking `rootPath` here as an absolute path (rather than a partial path we expand to an absolute path)
 	// to make it more testable.
 
@@ -17,10 +18,10 @@ func NewInitCmd(rootPath metadata.AbsPath, specFlag string, serverURI *string) (
 		return nil, err
 	}
 
-	return &InitCmd{rootPath: rootPath, spec: spec, serverURI: serverURI}, nil
+	return &InitCmd{rootPath: rootPath, spec: spec, serverURI: serverURI, namespace: namespace}, nil
 }
 
 func (c *InitCmd) Run() error {
-	_, err := metadata.Init(c.rootPath, c.spec, c.serverURI)
+	_, err := metadata.Init(c.rootPath, c.spec, c.serverURI, c.namespace)
 	return err
 }


### PR DESCRIPTION
**SEE [PR](https://github.com/ksonnet/kubecfg/pull/161) FROM OLD REPOSITORY FOR EXISTING COMMENTS**

**Fixes #9**

Environments currently have the concept of a server URI, but it is
ambiguous which cluster namespace to use.

This commit will introduce the concept of namespaces to the env
commands.

For example,
`kubecfg env add staging http://mock-staging-uri \
 --namespace=staging-namespace`
`kubecfg env set staging --namespace=staging-namespace`

The default environment will use the namespace of the default context.

This commit will also update commands that take the <env> arg such as
`apply` to make use of the env namespace, if specified.