### PR TITLE
Environment base.libsonnet and overrides

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,8 +59,6 @@ const (
 	// environment or the -f flag.
 	flagFile      = "file"
 	flagFileShort = "f"
-
-	componentsExtCodeKey = "__ksonnet/components"
 )
 
 var clientConfig clientcmd.ClientConfig
@@ -372,16 +370,17 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 			return nil, err
 		}
 
-		libPath, envLibPath := manager.LibPaths(*envSpec.env)
+		libPath, envLibPath, envComponentPath := manager.LibPaths(*envSpec.env)
 		expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
 
 		if !filesPresent {
-			fileNames, err = manager.ComponentPaths()
+			componentPaths, err := manager.ComponentPaths()
 			if err != nil {
 				return nil, err
 			}
-			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(fileNames))
+			baseObjExtCode := fmt.Sprintf("%s=%s", metadata.ComponentsExtCodeKey, constructBaseObj(componentPaths))
 			expander.ExtCodes = append([]string{baseObjExtCode}, expander.ExtCodes...)
+			fileNames = []string{string(envComponentPath)}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -381,7 +381,7 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 				return nil, err
 			}
 			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(fileNames))
-			expander.ExtCodes = append([]string{baseObjExtCode})
+			expander.ExtCodes = append([]string{baseObjExtCode}, expander.ExtCodes...)
 		}
 	}
 

--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	defaultEnvName = "default"
+	defaultEnvName  = "default"
+	metadataDirName = ".metadata"
 
 	schemaFilename        = "swagger.json"
 	extensionsLibFilename = "k.libsonnet"
@@ -87,11 +88,17 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 		return err
 	}
 
+	metadataPath := appendToAbsPath(envPath, metadataDirName)
+	err = m.appFS.MkdirAll(string(metadataPath), defaultFolderPermissions)
+	if err != nil {
+		return err
+	}
+
 	log.Infof("Generating environment metadata at path '%s'", envPath)
 
 	// Generate the schema file.
 	log.Debugf("Generating '%s', length: %d", schemaFilename, len(specData))
-	schemaPath := appendToAbsPath(envPath, schemaFilename)
+	schemaPath := appendToAbsPath(metadataPath, schemaFilename)
 	err = afero.WriteFile(m.appFS, string(schemaPath), specData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", schemaFilename)
@@ -99,7 +106,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	log.Debugf("Generating '%s', length: %d", k8sLibFilename, len(k8sLibData))
-	k8sLibPath := appendToAbsPath(envPath, k8sLibFilename)
+	k8sLibPath := appendToAbsPath(metadataPath, k8sLibFilename)
 	err = afero.WriteFile(m.appFS, string(k8sLibPath), k8sLibData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", k8sLibFilename)
@@ -107,7 +114,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	log.Debugf("Generating '%s', length: %d", extensionsLibFilename, len(extensionsLibData))
-	extensionsLibPath := appendToAbsPath(envPath, extensionsLibFilename)
+	extensionsLibPath := appendToAbsPath(metadataPath, extensionsLibFilename)
 	err = afero.WriteFile(m.appFS, string(extensionsLibPath), extensionsLibData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", extensionsLibFilename)

--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -123,7 +123,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 		return err
 	}
 
-	// Generate the base.libsonnet override file
+	// Generate the environment .jsonnet file
 	overrideFileName := path.Base(name) + ".jsonnet"
 	overrideData := m.generateOverrideData()
 	log.Debugf("Generating '%s', length: %d", overrideFileName, len(overrideData))
@@ -350,9 +350,10 @@ func (m *manager) generateKsonnetLibData(spec ClusterSpec) ([]byte, []byte, []by
 func (m *manager) generateOverrideData() []byte {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("local base = import \"%s\";\n", m.baseLibsonnetPath))
-	buf.WriteString(fmt.Sprintf("local k = import \"%s\";\n\n", path.Join(metadataDirName, extensionsLibFilename)))
+	buf.WriteString(fmt.Sprintf("local k = import \"%s\";\n\n", extensionsLibFilename))
 	buf.WriteString("base + {\n")
-	buf.WriteString("  // Insert user-specified overrides here.\n")
+	buf.WriteString("  // Insert user-specified overrides here. For example if a component is named \"nginx-deployment\", you might have something like:\n")
+	buf.WriteString("  //   \"nginx-deployment\"+: k.deployment.mixin.metadata.labels({foo: \"bar\"})\n")
 	buf.WriteString("}\n")
 	return buf.Bytes()
 }

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -180,3 +180,20 @@ func TestSetEnvironment(t *testing.T) {
 		t.Fatalf("Expected set URI to be \"%s\", got:\n  %s", set.URI, envSpec.URI)
 	}
 }
+
+func TestGenerateOverrideData(t *testing.T) {
+	m := mockEnvironments(t, "test-gen-override-data")
+
+	expected := `local base = import "test-gen-override-data/environments/base.libsonnet";
+local k = import ".metadata/k.libsonnet";
+
+base + {
+  // Insert user-specified overrides here.
+}
+`
+	result := m.generateOverrideData()
+
+	if string(result) != expected {
+		t.Fatalf("Expected to generate override file with data:\n%s\n,got:\n%s", expected, result)
+	}
+}

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -185,10 +185,11 @@ func TestGenerateOverrideData(t *testing.T) {
 	m := mockEnvironments(t, "test-gen-override-data")
 
 	expected := `local base = import "test-gen-override-data/environments/base.libsonnet";
-local k = import ".metadata/k.libsonnet";
+local k = import "k.libsonnet";
 
 base + {
-  // Insert user-specified overrides here.
+  // Insert user-specified overrides here. For example if a component is named "nginx-deployment", you might have something like:
+  //   "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
 }
 `
 	result := m.generateOverrideData()

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -43,7 +43,7 @@ type Manager interface {
 	Root() AbsPath
 	ComponentPaths() (AbsPaths, error)
 	CreateComponent(name string, text string, templateType prototype.TemplateType) error
-	LibPaths(envName string) (libPath, envLibPath AbsPath)
+	LibPaths(envName string) (libPath, envLibPath, envComponentPath AbsPath)
 	CreateEnvironment(name, uri string, spec ClusterSpec) error
 	DeleteEnvironment(name string) error
 	GetEnvironments() ([]*Environment, error)

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -40,6 +40,9 @@ const (
 	vendorDir       = "vendor"
 
 	baseLibsonnetFile = "base.libsonnet"
+
+	// ComponentsExtCodeKey is the ExtCode key for component imports
+	ComponentsExtCodeKey = "__ksonnet/components"
 )
 
 type manager struct {
@@ -175,8 +178,9 @@ func (m *manager) CreateComponent(name string, text string, templateType prototy
 	return afero.WriteFile(m.appFS, componentPath, []byte(text), defaultFilePermissions)
 }
 
-func (m *manager) LibPaths(envName string) (libPath, envLibPath AbsPath) {
-	return m.libPath, appendToAbsPath(m.environmentsPath, envName, metadataDirName)
+func (m *manager) LibPaths(envName string) (libPath, envLibPath, envComponentPath AbsPath) {
+	envPath := appendToAbsPath(m.environmentsPath, envName)
+	return m.libPath, appendToAbsPath(envPath, metadataDirName), appendToAbsPath(envPath, path.Base(envName)+".jsonnet")
 }
 
 func (m *manager) createAppDirTree() error {
@@ -206,8 +210,7 @@ func (m *manager) createAppDirTree() error {
 }
 
 func genBaseLibsonnetContent() []byte {
-	// TODO replace with constant ref once #164 is merged
-	return []byte(`local components = std.extVar("__ksonnet/components");
+	return []byte(`local components = std.extVar("` + ComponentsExtCodeKey + `");
 components + {
   // Insert user-specified overrides here.
 }

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -170,7 +170,7 @@ func (m *manager) CreateComponent(name string, text string, templateType prototy
 }
 
 func (m *manager) LibPaths(envName string) (libPath, envLibPath AbsPath) {
-	return m.libPath, appendToAbsPath(m.environmentsPath, envName)
+	return m.libPath, appendToAbsPath(m.environmentsPath, envName, metadataDirName)
 }
 
 func (m *manager) createAppDirTree() error {

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"fmt"
 	"os"
+	"path"
 	"sort"
 	"testing"
 
@@ -207,6 +208,21 @@ func TestComponentPaths(t *testing.T) {
 
 	if len(paths) != 2 || paths[0] != string(appFile2) || paths[1] != string(appFile1) {
 		t.Fatalf("m.ComponentPaths failed; expected '%s', got '%s'", []string{string(appFile1), string(appFile2)}, paths)
+	}
+}
+
+func TestLibPaths(t *testing.T) {
+	appName := "test-lib-paths"
+	expectedLibPath := path.Join(appName, libDir)
+	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
+	m := mockEnvironments(t, appName)
+
+	libPath, envLibPath := m.LibPaths(mockEnvName)
+	if string(libPath) != expectedLibPath {
+		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
+	}
+	if string(envLibPath) != expectedEnvLibPath {
+		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)
 	}
 }
 

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -215,14 +215,18 @@ func TestLibPaths(t *testing.T) {
 	appName := "test-lib-paths"
 	expectedLibPath := path.Join(appName, libDir)
 	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
+	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, path.Base(mockEnvName)+".jsonnet")
 	m := mockEnvironments(t, appName)
 
-	libPath, envLibPath := m.LibPaths(mockEnvName)
+	libPath, envLibPath, envComponentPath := m.LibPaths(mockEnvName)
 	if string(libPath) != expectedLibPath {
 		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
 	}
 	if string(envLibPath) != expectedEnvLibPath {
 		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)
+	}
+	if string(envComponentPath) != expectedEnvComponentPath {
+		t.Fatalf("Expected environment component path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvComponentPath, envComponentPath)
 	}
 }
 

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -84,8 +84,10 @@ func TestInitSuccess(t *testing.T) {
 		}
 	}
 
-	envPath := appendToAbsPath(appPath, string(defaultEnvDir))
-	schemaPath := appendToAbsPath(envPath, schemaFilename)
+	envPath := appendToAbsPath(appPath, string(environmentsDir))
+	metadataPath := appendToAbsPath(appPath, string(defaultEnvDir), string(metadataDirName))
+
+	schemaPath := appendToAbsPath(metadataPath, schemaFilename)
 	bytes, err := afero.ReadFile(testFS, string(schemaPath))
 	if err != nil {
 		t.Fatalf("Failed to read swagger file at '%s':\n%v", schemaPath, err)
@@ -93,7 +95,7 @@ func TestInitSuccess(t *testing.T) {
 		t.Fatalf("Expected swagger file at '%s' to have value: '%s', got: '%s'", schemaPath, blankSwaggerData, actualSwagger)
 	}
 
-	k8sLibPath := appendToAbsPath(envPath, k8sLibFilename)
+	k8sLibPath := appendToAbsPath(metadataPath, k8sLibFilename)
 	k8sLibBytes, err := afero.ReadFile(testFS, string(k8sLibPath))
 	if err != nil {
 		t.Fatalf("Failed to read ksonnet-lib file at '%s':\n%v", k8sLibPath, err)
@@ -101,7 +103,7 @@ func TestInitSuccess(t *testing.T) {
 		t.Fatalf("Expected swagger file at '%s' to have value: '%s', got: '%s'", k8sLibPath, blankK8sLib, actualK8sLib)
 	}
 
-	extensionsLibPath := appendToAbsPath(envPath, extensionsLibFilename)
+	extensionsLibPath := appendToAbsPath(metadataPath, extensionsLibFilename)
 	extensionsLibBytes, err := afero.ReadFile(testFS, string(extensionsLibPath))
 	if err != nil {
 		t.Fatalf("Failed to read ksonnet-lib file at '%s':\n%v", extensionsLibPath, err)

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -110,6 +110,14 @@ func TestInitSuccess(t *testing.T) {
 	} else if string(extensionsLibBytes) == "" {
 		t.Fatalf("Expected extension library file at '%s' to be non-empty", extensionsLibPath)
 	}
+
+	baseLibsonnetPath := appendToAbsPath(envPath, baseLibsonnetFile)
+	baseLibsonnetBytes, err := afero.ReadFile(testFS, string(baseLibsonnetPath))
+	if err != nil {
+		t.Fatalf("Failed to read base.libsonnet file at '%s':\n%v", baseLibsonnetPath, err)
+	} else if len(baseLibsonnetBytes) == 0 {
+		t.Fatalf("Expected base.libsonnet at '%s' to be non-empty", baseLibsonnetPath)
+	}
 }
 
 func TestFindSuccess(t *testing.T) {


### PR DESCRIPTION
**SEE [PR](https://github.com/ksonnet/kubecfg/pull/167) FROM OLD REPOSITORY FOR EXISTING COMMENTS**

Implements part of #6 . This PR does a few things:

1. Hide environment metadata details that we do not want users modifying in a `.metadata` folder (`k.libsonnet`, `k8s.libsonnet`, `swagger.json`)

2. Generate base.libsonnet:
base.libsonnet is a generated file that exists at the root of the
environments directory. This file is generated for all ksonnet projects.
The main goal of this file is to import all components in the components
directory, so that environments are able to easily extend / override any
one of these components in a modular structure.

3. Generate the override file:
Generate an "<env-name>.jsonnet" file when an environment is created.
The goal of this file is to allow users to extend on base.libsonnet on a
per-environment basis to allow for custom overrides, such as replica
count.
For example, the default environment would have the following tree
structure:
```
├── environments
│   ├── base.libsonnet
│   └── default
│       ├── .metadata
│       │   ├── k.libsonnet
│       │   ├── k8s.libsonnet
│       │   └── swagger.json
│       ├── default.jsonnet
│       └── spec.json
```

4. Expand the override file:
Commands that take `env` as a param currently expand all files in the
`components` directory. This is no longer necessary with the
introduction of `base.libsonnet` and the per-environment override
`<env>.jsonnet` file. This change will simply expand the single
`<env>.jsonnet` file (which will implicitly expand all component files).
The case of running `ksonnet apply default`, is equivalent to running
`ksonnet apply -f environments/default/default.jsonnet`.