### PR TITLE
Remove link to releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ now is on clearer error reporting and advanced features.
 
 ## Install
 
-Pre-compiled executables exist for some platforms on
-the [Github releases](https://github.com/ksonnet/ksonnet/releases)
-page.
-
 To build from source:
 
 ```console


### PR DESCRIPTION
ksonnet.next isn't released yet. This message remained as a port from
the original README file in the kubecfg project.