### PR TITLE
Jsonnet handling of component names with special characters

### DIFF
--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ksonnet/ksonnet/metadata"
 	"github.com/ksonnet/ksonnet/prototype"
 	"github.com/ksonnet/ksonnet/prototype/snippet/jsonnet"
+	"github.com/ksonnet/ksonnet/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -397,7 +398,11 @@ func expandPrototype(proto *prototype.SpecificationSchema, templateType prototyp
 		return "", err
 	}
 	if templateType == prototype.Jsonnet {
-		template = append([]string{`local params = std.extVar("` + metadata.ParamsExtCodeKey + `").components.` + componentName + ";"}, template...)
+		componentsText := "components." + componentName
+		if !utils.IsASCIIIdentifier(componentName) {
+			componentsText = fmt.Sprintf(`components["%s"]`, componentName)
+		}
+		template = append([]string{`local params = std.extVar("` + metadata.ParamsExtCodeKey + `").` + componentsText + ";"}, template...)
 	}
 
 	return jsonnet.Parse(componentName, strings.Join(template, "\n"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/ksonnet/ksonnet/metadata/params"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	log "github.com/sirupsen/logrus"
@@ -430,6 +432,7 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 //
 //   {
 //      foo: import "components/foo.jsonnet"
+//      "foo-bar": import "components/foo-bar.jsonnet"
 //   }
 func constructBaseObj(paths []string) string {
 	var obj bytes.Buffer
@@ -441,6 +444,7 @@ func constructBaseObj(paths []string) string {
 		}
 
 		name := strings.TrimSuffix(path.Base(p), ext)
+		name = params.SanitizeComponent(name)
 		fmt.Fprintf(&obj, "  %s: import \"%s\",\n", name, p)
 	}
 	obj.WriteString("}\n")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -65,6 +65,16 @@ func TestConstructBaseObj(t *testing.T) {
 }
 `,
 		},
+		// test special character case
+		{
+			[]string{
+				"another/fake/path/foo-bar.jsonnet",
+			},
+			`{
+  "foo-bar": import "another/fake/path/foo-bar.jsonnet",
+}
+`,
+		},
 	}
 
 	for _, s := range tests {

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -1,0 +1,32 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"strings"
+)
+
+// HasSpecialCharacter takes a string and returns true if the string contains
+// any special characters.
+func IsASCIIIdentifier(s string) bool {
+	f := func(r rune) bool {
+		return r < 'A' || r > 'z'
+	}
+	if strings.IndexFunc(s, f) != -1 {
+		return false
+	}
+	return true
+}

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -1,0 +1,53 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsASCIIIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "HelloWorld",
+			expected: true,
+		},
+		{
+			input:    "Hello World",
+			expected: false,
+		},
+		{
+			input:    "helloworld",
+			expected: true,
+		},
+		{
+			input:    "hello-world",
+			expected: false,
+		},
+		{
+			input:    "hello世界",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		require.EqualValues(t, test.expected, IsASCIIIdentifier(test.input))
+	}
+}


### PR DESCRIPTION
Currently, if a component name contains a special character, ex:
foo-bar, this translates to the jsonnet identifier: foo-bar, which is
invalid syntax.

This change will quote component names where there are special
characters.

Fixes #51 