### PR TITLE
Pass context & overrides by reference when initiating client

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -270,10 +270,10 @@ func initDiffRemoteCmd(localEnv, remoteEnv, diffStrategy string, cmd *cobra.Comm
 }
 
 func setupClientConfig(env *string, cmd *cobra.Command) (dynamic.ClientPool, discovery.DiscoveryInterface, string, error) {
-	overrides := clientcmd.ConfigOverrides{}
+	overrides := &clientcmd.ConfigOverrides{}
 	loadingRules := *clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	config := clientcmd.NewInteractiveDeferredLoadingClientConfig(&loadingRules, &overrides, os.Stdin)
+	config := clientcmd.NewInteractiveDeferredLoadingClientConfig(&loadingRules, overrides, os.Stdin)
 
 	clientPool, discovery, err := restClient(cmd, env, config, overrides)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,10 +121,10 @@ var RootCmd = &cobra.Command{
 // clientConfig.Namespace() is broken in client-go 3.0:
 // namespace in config erroneously overrides explicit --namespace
 func namespace() (string, error) {
-	return namespaceFor(clientConfig, overrides)
+	return namespaceFor(clientConfig, &overrides)
 }
 
-func namespaceFor(c clientcmd.ClientConfig, overrides clientcmd.ConfigOverrides) (string, error) {
+func namespaceFor(c clientcmd.ClientConfig, overrides *clientcmd.ConfigOverrides) (string, error) {
 	if overrides.Context.Namespace != "" {
 		return overrides.Context.Namespace, nil
 	}
@@ -260,7 +260,7 @@ func dumpJSON(v interface{}) string {
 	return string(buf.Bytes())
 }
 
-func restClient(cmd *cobra.Command, envName *string, config clientcmd.ClientConfig, overrides clientcmd.ConfigOverrides) (dynamic.ClientPool, discovery.DiscoveryInterface, error) {
+func restClient(cmd *cobra.Command, envName *string, config clientcmd.ClientConfig, overrides *clientcmd.ConfigOverrides) (dynamic.ClientPool, discovery.DiscoveryInterface, error) {
 	if envName != nil {
 		err := overrideCluster(*envName, config, overrides)
 		if err != nil {
@@ -287,7 +287,7 @@ func restClient(cmd *cobra.Command, envName *string, config clientcmd.ClientConf
 }
 
 func restClientPool(cmd *cobra.Command, envName *string) (dynamic.ClientPool, discovery.DiscoveryInterface, error) {
-	return restClient(cmd, envName, clientConfig, overrides)
+	return restClient(cmd, envName, clientConfig, &overrides)
 }
 
 type envSpec struct {
@@ -326,7 +326,7 @@ func parseEnvCmd(cmd *cobra.Command, args []string) (*envSpec, error) {
 // If the environment server the user is attempting to deploy to is not the current
 // kubeconfig context, we must manually override the client-go --cluster flag
 // to ensure we are deploying to the correct cluster.
-func overrideCluster(envName string, clientConfig clientcmd.ClientConfig, overrides clientcmd.ConfigOverrides) error {
+func overrideCluster(envName string, clientConfig clientcmd.ClientConfig, overrides *clientcmd.ConfigOverrides) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes the bug where objects weren't being deployed to the cluster
specified by the environment. This bug occurred because overrides (ex:
cluster, namespace) were being lost because we weren't applying the
changes to the correct override object. To fix this, we needed to pass
the overrides by reference.

Fixes #53 