### PR TITLE
Add ability to retrieve prototypes from vendor/

### DIFF
--- a/metadata/app/schema.go
+++ b/metadata/app/schema.go
@@ -89,6 +89,7 @@ type RegistryRefSpecs map[string]*RegistryRefSpec
 
 type LibraryRefSpec struct {
 	Name       string          `json:"name"`
+	Registry   string          `json:"registry"`
 	GitVersion *GitVersionSpec `json:"gitVersion"`
 }
 

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -72,10 +72,11 @@ type Manager interface {
 	// Spec API.
 	AppSpec() (*app.Spec, error)
 
-	// Registry API.
+	// Dependency/registry API.
 	AddRegistry(name, protocol, uri, version string) (*registry.Spec, error)
 	GetRegistry(name string) (*registry.Spec, string, error)
 	CacheDependency(registryName, libID, libName, libVersion string) (*parts.Spec, error)
+	GetAllPrototypes() (prototype.SpecificationSchemas, error)
 }
 
 // Find will recursively search the current directory and its parents for a

--- a/metadata/registry_managers.go
+++ b/metadata/registry_managers.go
@@ -153,7 +153,8 @@ func (gh *gitHubRegistryManager) ResolveLibrary(libID, libAlias, libRefSpec stri
 	json.Unmarshal([]byte(partsSpecText), &parts)
 
 	refSpec := app.LibraryRefSpec{
-		Name: libAlias,
+		Name:     libAlias,
+		Registry: gh.Name,
 		GitVersion: &app.GitVersionSpec{
 			RefSpec:   libRefSpec,
 			CommitSHA: resolvedSHA,


### PR DESCRIPTION
Just a note, the prototype comment parsing comes out of the ksonnet/parts doc gen code, so this is not actually new. We will eventually pull that out and vendor this into that project.