### PR TITLE
Add `vendor/` to Jsonnet paths

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -295,7 +295,7 @@ func expandEnvObjs(cmd *cobra.Command, env string, manager metadata.Manager) ([]
 		return nil, err
 	}
 
-	libPath, envLibPath, envComponentPath, envParamsPath := manager.LibPaths(env)
+	libPath, vendorPath, envLibPath, envComponentPath, envParamsPath := manager.LibPaths(env)
 
 	componentPaths, err := manager.ComponentPaths()
 	if err != nil {
@@ -304,7 +304,7 @@ func expandEnvObjs(cmd *cobra.Command, env string, manager metadata.Manager) ([]
 	baseObj := constructBaseObj(componentPaths)
 	params := importParams(string(envParamsPath))
 
-	expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
+	expander.FlagJpath = append([]string{string(libPath), string(vendorPath), string(envLibPath)}, expander.FlagJpath...)
 	expander.ExtCodes = append([]string{baseObj, params}, expander.ExtCodes...)
 
 	envFiles := []string{string(envComponentPath)}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -402,8 +402,8 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 			return nil, err
 		}
 
-		libPath, envLibPath, envComponentPath, envParamsPath := manager.LibPaths(*envSpec.env)
-		expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
+		libPath, vendorPath, envLibPath, envComponentPath, envParamsPath := manager.LibPaths(*envSpec.env)
+		expander.FlagJpath = append([]string{string(libPath), string(vendorPath), string(envLibPath)}, expander.FlagJpath...)
 
 		if !filesPresent {
 			componentPaths, err := manager.ComponentPaths()

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -45,7 +45,7 @@ type AbsPaths []string
 // libraries; and other non-core-application tasks.
 type Manager interface {
 	Root() AbsPath
-	LibPaths(envName string) (libPath, envLibPath, envComponentPath, envParamsPath AbsPath)
+	LibPaths(envName string) (libPath, vendorPath, envLibPath, envComponentPath, envParamsPath AbsPath)
 
 	// Components API.
 	ComponentPaths() (AbsPaths, error)

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -252,9 +252,9 @@ func (m *manager) CreateComponent(name string, text string, params param.Params,
 	return m.writeComponentParams(name, params)
 }
 
-func (m *manager) LibPaths(envName string) (libPath, envLibPath, envComponentPath, envParamsPath AbsPath) {
+func (m *manager) LibPaths(envName string) (libPath, vendorPath, envLibPath, envComponentPath, envParamsPath AbsPath) {
 	envPath := appendToAbsPath(m.environmentsPath, envName)
-	return m.libPath, appendToAbsPath(envPath, metadataDirName),
+	return m.libPath, m.vendorPath, appendToAbsPath(envPath, metadataDirName),
 		appendToAbsPath(envPath, path.Base(envName)+".jsonnet"), appendToAbsPath(envPath, componentParamsFile)
 }
 

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -263,15 +263,19 @@ func TestComponentPaths(t *testing.T) {
 
 func TestLibPaths(t *testing.T) {
 	appName := "test-lib-paths"
+	expectedVendorPath := path.Join(appName, vendorDir)
 	expectedLibPath := path.Join(appName, libDir)
 	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
 	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, path.Base(mockEnvName)+".jsonnet")
 	expectedEnvParamsPath := path.Join(appName, environmentsDir, mockEnvName, paramsFileName)
 	m := mockEnvironments(t, appName)
 
-	libPath, envLibPath, envComponentPath, envParamsPath := m.LibPaths(mockEnvName)
+	libPath, vendorPath, envLibPath, envComponentPath, envParamsPath := m.LibPaths(mockEnvName)
 	if string(libPath) != expectedLibPath {
 		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
+	}
+	if string(vendorPath) != expectedVendorPath {
+		t.Fatalf("Expected vendor lib path to be:\n  '%s'\n, got:\n  '%s'", expectedVendorPath, vendorPath)
 	}
 	if string(envLibPath) != expectedEnvLibPath {
 		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)


### PR DESCRIPTION
This resolves the first half of #68. When we `generate` using a
prototype from a vendored dependency, it often results in a compilation
error when we `apply`, because these prototypes usually depend on code
that exists in the dependency, and `vendor/` is not a part of the
Jsonnet search path.

This commit resolves this problem by adding it to the search path.