### PR TITLE
De/serialize specification objects with YAML

### DIFF
--- a/metadata/app/schema.go
+++ b/metadata/app/schema.go
@@ -16,12 +16,13 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/ghodss/yaml"
 )
 
 const (
-	DefaultAPIVersion = "0.1"
+	DefaultAPIVersion = "0.0.1"
 	Kind              = "ksonnet.io/app"
 	DefaultVersion    = "0.0.1"
 )
@@ -46,7 +47,7 @@ type Spec struct {
 }
 
 func (s *Spec) Marshal() ([]byte, error) {
-	return json.MarshalIndent(s, "", "  ")
+	return yaml.Marshal(s)
 }
 
 func (s *Spec) GetRegistryRef(name string) (*RegistryRefSpec, bool) {
@@ -79,7 +80,7 @@ type RepositorySpec struct {
 }
 
 type RegistryRefSpec struct {
-	Name       string
+	Name       string          `json:"-"`
 	Protocol   string          `json:"protocol"`
 	URI        string          `json:"uri"`
 	GitVersion *GitVersionSpec `json:"gitVersion"`

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -16,7 +16,6 @@
 package metadata
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/user"
@@ -24,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/ksonnet/ksonnet/metadata/app"
 	param "github.com/ksonnet/ksonnet/metadata/params"
 	"github.com/ksonnet/ksonnet/metadata/registry"
@@ -299,7 +299,7 @@ func (m *manager) AppSpec() (*app.Spec, error) {
 	}
 
 	schema := app.Spec{}
-	err = json.Unmarshal(bytes, &schema)
+	err = yaml.Unmarshal(bytes, &schema)
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/parts/schema.go
+++ b/metadata/parts/schema.go
@@ -15,7 +15,9 @@
 
 package parts
 
-import "encoding/json"
+import (
+	"github.com/ghodss/yaml"
+)
 
 const (
 	DefaultApiVersion = "0.1"
@@ -40,7 +42,7 @@ type Spec struct {
 }
 
 func (s *Spec) Marshal() ([]byte, error) {
-	return json.MarshalIndent(s, "", "  ")
+	return yaml.Marshal(s)
 }
 
 type ContributorSpec struct {

--- a/metadata/registry.go
+++ b/metadata/registry.go
@@ -1,11 +1,11 @@
 package metadata
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/ghodss/yaml"
 	"github.com/ksonnet/ksonnet/metadata/app"
 	"github.com/ksonnet/ksonnet/metadata/parts"
 	"github.com/ksonnet/ksonnet/metadata/registry"
@@ -254,7 +254,7 @@ func (m *manager) registrySpecFromFile(path AbsPath) (*registry.Spec, bool, erro
 		}
 
 		registrySpec := registry.Spec{}
-		err = json.Unmarshal(registrySpecBytes, &registrySpec)
+		err = yaml.Unmarshal(registrySpecBytes, &registrySpec)
 		if err != nil {
 			return nil, false, err
 		}

--- a/metadata/registry/schema.go
+++ b/metadata/registry/schema.go
@@ -16,8 +16,7 @@
 package registry
 
 import (
-	"encoding/json"
-
+	"github.com/ghodss/yaml"
 	"github.com/ksonnet/ksonnet/metadata/app"
 )
 
@@ -34,7 +33,7 @@ type Spec struct {
 }
 
 func (s *Spec) Marshal() ([]byte, error) {
-	return json.MarshalIndent(s, "", "  ")
+	return yaml.Marshal(s)
 }
 
 type Specs []*Spec

--- a/metadata/registry_managers.go
+++ b/metadata/registry_managers.go
@@ -2,12 +2,12 @@ package metadata
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/google/go-github/github"
 	"github.com/ksonnet/ksonnet/metadata/app"
 	"github.com/ksonnet/ksonnet/metadata/parts"
@@ -99,7 +99,7 @@ func (gh *gitHubRegistryManager) FetchRegistrySpec() (*registry.Spec, error) {
 
 	// Deserialize, return.
 	registrySpec := registry.Spec{}
-	err = json.Unmarshal([]byte(registrySpecText), &registrySpec)
+	err = yaml.Unmarshal([]byte(registrySpecText), &registrySpec)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (gh *gitHubRegistryManager) ResolveLibrary(libID, libAlias, libRefSpec stri
 	}
 
 	parts := parts.Spec{}
-	json.Unmarshal([]byte(partsSpecText), &parts)
+	yaml.Unmarshal([]byte(partsSpecText), &parts)
 
 	refSpec := app.LibraryRefSpec{
 		Name:     libAlias,

--- a/prototype/interface.go
+++ b/prototype/interface.go
@@ -1,12 +1,12 @@
 package prototype
 
-import "encoding/json"
+import "github.com/ghodss/yaml"
 
 // Unmarshal takes the bytes of a JSON-encoded prototype specification, and
 // deserializes them to a `SpecificationSchema`.
 func Unmarshal(bytes []byte) (*SpecificationSchema, error) {
 	var p SpecificationSchema
-	err := json.Unmarshal(bytes, &p)
+	err := yaml.Unmarshal(bytes, &p)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #48.

Currently the structs `app.Spec`, `registry.Spec`, and `parts.Spec` are
all serialized and deserialized using JSON instead of YAML.

This commit will resolve this issue.