### PR TITLE
Fix bug for duplicate environment params

### DIFF
--- a/metadata/params/params.go
+++ b/metadata/params/params.go
@@ -187,7 +187,6 @@ func visitComponentsObj(component, snippet string) (*ast.Object, error) {
 }
 
 func appendComponent(component, snippet string, params Params) (string, error) {
-	component = SanitizeComponent(component)
 	componentsNode, err := visitComponentsObj(component, snippet)
 	if err != nil {
 		return "", err
@@ -208,7 +207,7 @@ func appendComponent(component, snippet string, params Params) (string, error) {
 
 	// Create the jsonnet resembling the component params
 	var buffer bytes.Buffer
-	buffer.WriteString("    " + component + ": {")
+	buffer.WriteString("    " + SanitizeComponent(component) + ": {")
 	buffer.WriteString(writeParams(6, params))
 	buffer.WriteString("    },")
 
@@ -340,7 +339,6 @@ func getAllEnvironmentParams(snippet string) (map[string]Params, error) {
 }
 
 func setEnvironmentParams(component, snippet string, params Params) (string, error) {
-	component = SanitizeComponent(component)
 	currentParams, loc, hasComponent, err := getEnvironmentParams(component, snippet)
 	if err != nil {
 		return "", err
@@ -357,7 +355,7 @@ func setEnvironmentParams(component, snippet string, params Params) (string, err
 	lines := strings.Split(snippet, "\n")
 	if !hasComponent {
 		var buffer bytes.Buffer
-		buffer.WriteString(fmt.Sprintf("\n    %s +: {", component))
+		buffer.WriteString(fmt.Sprintf("\n    %s +: {", SanitizeComponent(component)))
 		buffer.WriteString(writeParams(6, params))
 		buffer.WriteString("    },\n")
 		paramsSnippet = buffer.String()

--- a/metadata/params/params_test.go
+++ b/metadata/params/params_test.go
@@ -657,6 +657,29 @@ params + {
   },
 }`,
 		},
+		// Test setting environment param case where component name is a string identifier
+		{
+			"foo-bar",
+			`
+local params = import "/fake/path";
+params + {
+  components +: {
+    "foo-bar" +: {
+      name: "foo-bar",
+    },
+  },
+}`,
+			Params{"name": `"foo"`},
+			`
+local params = import "/fake/path";
+params + {
+  components +: {
+    "foo-bar" +: {
+      name: "foo",
+    },
+  },
+}`,
+		},
 		// Test environment param case with multiple components
 		{
 			"foo",

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 )
 
-// HasSpecialCharacter takes a string and returns true if the string contains
-// any special characters.
+// IsASCIIIdentifier takes a string and returns true if the string does not
+// contain any special characters.
 func IsASCIIIdentifier(s string) bool {
 	f := func(r rune) bool {
 		return r < 'A' || r > 'z'


### PR DESCRIPTION
A bug existed where if `param set` was called for the same param twice,
a duplicate entry was created for the component. This only occured where
the component name contained a special character.

Fixes #80 