### PR TITLE
Add more useful error when attempting to 'show' files in components/

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/ksonnet/ksonnet/metadata"
@@ -67,6 +68,8 @@ var showCmd = &cobra.Command{
 
 		objs, err := expandEnvCmdObjs(cmd, envSpec, wd)
 		if err != nil {
+			log.Info("Jsonnet files in components/ aren't able to be expanded without an environment. " +
+				"Consider running this command with the format: `ks show <env> -f <file>.")
 			return err
 		}
 


### PR DESCRIPTION
If an env isn't supplied with the kubecfg show -f <FILE> command, where
the file is present in the components/ directory, kubecfg can't load the
appropriate ksonnet lib files from /environments with the -J flag.

This commit adds an INFO message on `show` failures related to expanding
the jsonnet file that provides the user with more context.

Fixes #13 