### PR TITLE
🆘 Add `--help` flag to `generate` and `prototype use`

### DIFF
--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -333,6 +333,10 @@ var prototypeUseCmd = &cobra.Command{
 	Short:              `Expand prototype, place in components/ directory of ksonnet app`,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, rawArgs []string) error {
+		if len(rawArgs) == 1 && (rawArgs[0] == "--help" || rawArgs[0] == "-h") {
+			return cmd.Help()
+		}
+
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err


### PR DESCRIPTION
When `generate` was first implemented, we made a conscious decision to
not include the `--help` flag, so that we would not accidentally break
templates with a parameter called `help`.

But, this is unintuitive for users who want to use the `--help` flag, so
in this commit we will print the help message if (1) there is a single
command argument, and (2) it is either `--help` or `-h`.

Fixes #21.