### PR TITLE
YAML, JSON handling for prototype commands

### DIFF
--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ksonnet/ksonnet/metadata"
 	"github.com/ksonnet/ksonnet/prototype"
+	"github.com/ksonnet/ksonnet/prototype/snippet"
 	"github.com/ksonnet/ksonnet/prototype/snippet/jsonnet"
 	"github.com/ksonnet/ksonnet/utils"
 	"github.com/spf13/cobra"
@@ -450,9 +451,11 @@ func expandPrototype(proto *prototype.SpecificationSchema, templateType prototyp
 			componentsText = fmt.Sprintf(`components["%s"]`, componentName)
 		}
 		template = append([]string{`local params = std.extVar("` + metadata.ParamsExtCodeKey + `").` + componentsText + ";"}, template...)
+		return jsonnet.Parse(componentName, strings.Join(template, "\n"))
 	}
 
-	return jsonnet.Parse(componentName, strings.Join(template, "\n"))
+	tm := snippet.Parse(strings.Join(template, "\n"))
+	return tm.Evaluate(params)
 }
 
 func getParameters(proto *prototype.SpecificationSchema, flags *pflag.FlagSet) (map[string]string, error) {

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -309,13 +309,6 @@ unique enough to resolve to 'io.ksonnet.pkg.single-port-deployment'.`,
   # introduction of help message for more information on how this works.
   ks prototype preview simple-deployment \
     --name=nginx                              \
-    --image=nginx
-
-  # Preview prototype 'io.ksonnet.pkg.single-port-deployment' as YAML,
-  # placing the result in 'components/nginx-depl.yaml. Note that some templates
-  # do not have a YAML or JSON versions.
-  ks prototype preview deployment nginx-depl yaml \
-    --name=nginx                                       \
     --image=nginx`,
 }
 
@@ -414,10 +407,6 @@ ksonnet will expand templates as Jsonnet).
     --name=nginx                                                         \
     --image=nginx
 
-Note that if we were to specify to expand the template as JSON or YAML, we would
-generate a file with a '.json' or '.yaml' extension, respectively. See examples
-below for an example of how to do this.
-
 Note also that 'prototype-name' need only contain enough of the suffix of a name
 to uniquely disambiguate it among known names. For example, 'deployment' may
 resolve ambiguously, in which case 'use' will fail, while 'deployment' might be
@@ -436,13 +425,6 @@ unique enough to resolve to 'io.ksonnet.pkg.single-port-deployment'.`,
   # information on how this works. Note that if you have imported another
   # prototype with this suffix, this may resolve ambiguously for you.
   ks prototype use deployment nginx-depl \
-    --name=nginx                              \
-    --image=nginx
-
-  # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' as YAML,
-  # placing the result in 'components/nginx-depl.yaml. Note that some templates
-  # do not have a YAML or JSON versions.
-  ks prototype use deployment nginx-depl yaml \
     --name=nginx                              \
     --image=nginx`,
 }

--- a/docs/cli-reference/ks_generate.md
+++ b/docs/cli-reference/ks_generate.md
@@ -16,10 +16,6 @@ ksonnet will expand templates as Jsonnet).
     --name=nginx                                                         \
     --image=nginx
 
-Note that if we were to specify to expand the template as JSON or YAML, we would
-generate a file with a '.json' or '.yaml' extension, respectively. See examples
-below for an example of how to do this.
-
 Note also that 'prototype-name' need only contain enough of the suffix of a name
 to uniquely disambiguate it among known names. For example, 'deployment' may
 resolve ambiguously, in which case 'use' will fail, while 'deployment' might be

--- a/docs/cli-reference/ks_prototype_preview.md
+++ b/docs/cli-reference/ks_prototype_preview.md
@@ -32,13 +32,6 @@ ks prototype preview <prototype-name> [type] [parameter-flags]
   ks prototype preview simple-deployment \
     --name=nginx                              \
     --image=nginx
-
-  # Preview prototype 'io.ksonnet.pkg.single-port-deployment' as YAML,
-  # placing the result in 'components/nginx-depl.yaml. Note that some templates
-  # do not have a YAML or JSON versions.
-  ks prototype preview deployment nginx-depl yaml \
-    --name=nginx                                       \
-    --image=nginx
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ks_prototype_use.md
+++ b/docs/cli-reference/ks_prototype_use.md
@@ -16,10 +16,6 @@ ksonnet will expand templates as Jsonnet).
     --name=nginx                                                         \
     --image=nginx
 
-Note that if we were to specify to expand the template as JSON or YAML, we would
-generate a file with a '.json' or '.yaml' extension, respectively. See examples
-below for an example of how to do this.
-
 Note also that 'prototype-name' need only contain enough of the suffix of a name
 to uniquely disambiguate it among known names. For example, 'deployment' may
 resolve ambiguously, in which case 'use' will fail, while 'deployment' might be
@@ -45,13 +41,6 @@ ks prototype use <prototype-name> <componentName> [type] [parameter-flags]
   # information on how this works. Note that if you have imported another
   # prototype with this suffix, this may resolve ambiguously for you.
   ks prototype use deployment nginx-depl \
-    --name=nginx                              \
-    --image=nginx
-
-  # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' as YAML,
-  # placing the result in 'components/nginx-depl.yaml. Note that some templates
-  # do not have a YAML or JSON versions.
-  ks prototype use deployment nginx-depl yaml \
     --name=nginx                              \
     --image=nginx
 ```


### PR DESCRIPTION
fixes #64

Remove YAML, JSON examples from prototype command descriptions.
Fixes a bug where non-Jsonnet prototypes were expanded using incorrect parser.