### PR TITLE
Rename <env>.jsonnet file to main.jsonnet

### DIFF
--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -47,6 +47,17 @@ const (
 	specFilename   = "spec.json"
 )
 
+var envPaths = []string{
+	// metadata Dir.wh
+	metadataDirName,
+	// environment base override file
+	envFileName,
+	// params file
+	paramsFileName,
+	// spec file
+	specFilename,
+}
+
 // Environment represents all fields of a ksonnet environment
 type Environment struct {
 	Path      string
@@ -292,22 +303,36 @@ func (m *manager) SetEnvironment(name string, desired *Environment) error {
 		if err != nil {
 			return err
 		}
+
 		if exists {
-			return fmt.Errorf("Failed to create environment, directory exists at path: %s", string(pathNew))
+			// we know that the desired path is not an environment from
+			// the check earlier. This is an intermediate directory.
+			// We need to move the file contents.
+			m.tryMvEnvDir(pathOld, pathNew)
+		} else if filepath.HasPrefix(string(pathNew), string(pathOld)) {
+			// the new directory is a child of the old directory --
+			// rename won't work.
+			err = m.appFS.MkdirAll(string(pathNew), defaultFolderPermissions)
+			if err != nil {
+				return err
+			}
+			m.tryMvEnvDir(pathOld, pathNew)
+		} else {
+			// Need to first create subdirectories that don't exist
+			intermediatePath := path.Dir(string(pathNew))
+			log.Debugf("Moving directory at path '%s' to '%s'", string(pathOld), string(pathNew))
+			err = m.appFS.MkdirAll(intermediatePath, defaultFolderPermissions)
+			if err != nil {
+				return err
+			}
+			// finally, move the directory
+			err = m.appFS.Rename(string(pathOld), string(pathNew))
+			if err != nil {
+				log.Debugf("Failed to move path '%s' to '%s", string(pathOld), string(pathNew))
+				return err
+			}
 		}
-		// Need to first create subdirectories that don't exist
-		intermediatePath := path.Dir(string(pathNew))
-		log.Debugf("Moving directory at path '%s' to '%s'", string(pathOld), string(pathNew))
-		err = m.appFS.MkdirAll(intermediatePath, defaultFolderPermissions)
-		if err != nil {
-			return err
-		}
-		// finally, move the directory
-		err = m.appFS.Rename(string(pathOld), string(pathNew))
-		if err != nil {
-			log.Debugf("Failed to move path '%s' to '%s", string(pathOld), string(pathNew))
-			return err
-		}
+
 		// clean up any empty parent directory paths
 		err = m.cleanEmptyParentDirs(name)
 		if err != nil {
@@ -411,6 +436,34 @@ func (m *manager) SetEnvironmentParams(env, component string, params param.Param
 	}
 
 	log.Debugf("Successfully set parameters for component '%s' at environment '%s'", component, env)
+	return nil
+}
+
+func (m *manager) tryMvEnvDir(dirPathOld, dirPathNew AbsPath) error {
+	// first ensure none of these paths exists in the new directory
+	for _, p := range envPaths {
+		path := string(appendToAbsPath(dirPathNew, p))
+		if exists, err := afero.Exists(m.appFS, path); err != nil {
+			return err
+		} else if exists {
+			return fmt.Errorf("%s already exists", path)
+		}
+	}
+
+	// note: afero and go does not provide simple ways to move the
+	// contents. We'll have to rename them individually.
+	for _, p := range envPaths {
+		err := m.appFS.Rename(string(appendToAbsPath(dirPathOld, p)), string(appendToAbsPath(dirPathNew, p)))
+		if err != nil {
+			return err
+		}
+	}
+	// clean up the old directory if it is empty
+	if empty, err := afero.IsEmpty(m.appFS, string(dirPathOld)); err != nil {
+		return err
+	} else if empty {
+		return m.appFS.RemoveAll(string(dirPathOld))
+	}
 	return nil
 }
 

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -255,7 +255,7 @@ func (m *manager) CreateComponent(name string, text string, params param.Params,
 func (m *manager) LibPaths(envName string) (libPath, vendorPath, envLibPath, envComponentPath, envParamsPath AbsPath) {
 	envPath := appendToAbsPath(m.environmentsPath, envName)
 	return m.libPath, m.vendorPath, appendToAbsPath(envPath, metadataDirName),
-		appendToAbsPath(envPath, path.Base(envName)+".jsonnet"), appendToAbsPath(envPath, componentParamsFile)
+		appendToAbsPath(envPath, envFileName), appendToAbsPath(envPath, componentParamsFile)
 }
 
 func (m *manager) GetComponentParams(component string) (param.Params, error) {

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -266,7 +266,7 @@ func TestLibPaths(t *testing.T) {
 	expectedVendorPath := path.Join(appName, vendorDir)
 	expectedLibPath := path.Join(appName, libDir)
 	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
-	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, path.Base(mockEnvName)+".jsonnet")
+	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, envFileName)
 	expectedEnvParamsPath := path.Join(appName, environmentsDir, mockEnvName, paramsFileName)
 	m := mockEnvironments(t, appName)
 


### PR DESCRIPTION
Currently, creating a `dev` environment will create a file
`dev.jsonnet`. Creating a `prod` environment will create a file
`prod.jsonnet`. This is a little more complex and prone to error than it
needs to be, especially when we are renaming environments. It will also
make this file easier to refer to in documentation if we give the file a
static name -- `main.jsonnet`.

Fixes #77 

--

Also, support renaming of environments to parent and child directories.

Fixes #76 