### PR TITLE
Fix `nil` dereference error in #129

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,10 @@ func resolveContext(context *string) (server, namespace string, err error) {
 	}
 
 	log.Infof("Using context '%s'", ctxName)
-	cluster := rawConfig.Clusters[ctx.Cluster]
+	cluster, exists := rawConfig.Clusters[ctx.Cluster]
+	if !exists {
+		return "", "", fmt.Errorf("No cluster with name '%s' exists", ctx.Cluster)
+	}
 	return cluster.Server, ctx.Namespace, nil
 }
 


### PR DESCRIPTION
In line 161 of `root.go`, we're failing to check whether a cluster in
the $KUBECONFIG clusters array exists before using it. This will cause a
`nil` dereference error.