### PR TITLE
Improve logging for init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ksonnet/ksonnet/metadata"
 	"github.com/ksonnet/ksonnet/pkg/kubecfg"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -59,6 +60,8 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		log.Infof("Creating a new app '%s' at path '%s'", appName, appRoot)
 
 		// Find the URI and namespace of the current cluster, if it exists.
 		var ctx *string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,7 +156,7 @@ func resolveContext(context *string) (server, namespace string, err error) {
 		return "", "", fmt.Errorf("context '%s' does not exist in the kubeconfig file", ctxName)
 	}
 
-	log.Infof("Using context '%s'", ctxName)
+	log.Infof("Using context '%s' from the kubeconfig file specified at the environment variable $KUBECONFIG", ctxName)
 	cluster, exists := rawConfig.Clusters[ctx.Cluster]
 	if !exists {
 		return "", "", fmt.Errorf("No cluster with name '%s' exists", ctx.Cluster)

--- a/pkg/kubecfg/init.go
+++ b/pkg/kubecfg/init.go
@@ -1,6 +1,9 @@
 package kubecfg
 
-import "github.com/ksonnet/ksonnet/metadata"
+import (
+	"github.com/ksonnet/ksonnet/metadata"
+	log "github.com/sirupsen/logrus"
+)
 
 type InitCmd struct {
 	name      string
@@ -24,5 +27,8 @@ func NewInitCmd(name string, rootPath metadata.AbsPath, specFlag string, serverU
 
 func (c *InitCmd) Run() error {
 	_, err := metadata.Init(c.name, c.rootPath, c.spec, c.serverURI, c.namespace)
+	if err == nil {
+		log.Info("ksonnet app successfully created! Next, try creating a component with `ks generate`.")
+	}
 	return err
 }


### PR DESCRIPTION
Fixes #115 

- Add message:  Creating a new app 'foo' at path '/path/to/foo'
- On success, add message:  ksonnet app successfully created! Next, try
  creating a component with `ks generate`
- On failure, provide suggestions for the user.
- Make note that the context is retrieved from the kubeconfig file at
  the environment variable $KUBECONFIG