### PR TITLE
[docs][prototypes] Rename 'deployment-exposed-with-service' and address README feedback

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -92,7 +92,7 @@ Why is this useful? Prototypes allow you to avoid copying and pasting boilerplat
 
 ![prototype parameter component diagram](/docs/img/prototype_and_parameters.svg)
 
-Out of the box, ksonnet comes with some system prototypes (like `io.ksonnet.pkg.deployment-exposed-with-service`) that you can explore with the various [`ks prototype`](docs/cli-reference/ks_prototype.md) commands. See [*package*](#package) for information on downloading or sharing additional prototypes.
+Out of the box, ksonnet comes with some system prototypes (like `io.ksonnet.pkg.deployed-service`) that you can explore with the various [`ks prototype`](docs/cli-reference/ks_prototype.md) commands. See [*package*](#package) for information on downloading or sharing additional prototypes.
 
 ---
 

--- a/prototype/prototype_test.go
+++ b/prototype/prototype_test.go
@@ -113,7 +113,7 @@ func TestSearch(t *testing.T) {
 		"io.ksonnet.pkg.single-port-service",
 		"io.ksonnet.pkg.namespace",
 		"io.ksonnet.pkg.configMap",
-		"io.ksonnet.pkg.deployment-exposed-with-service",
+		"io.ksonnet.pkg.deployed-service",
 		"io.ksonnet.pkg.single-port-deployment",
 	})
 	assertSearch(t, idx, Prefix, "foo", []string{})
@@ -121,7 +121,7 @@ func TestSearch(t *testing.T) {
 	// Suffix searches.
 	assertSearch(t, idx, Suffix, "service", []string{
 		"io.ksonnet.pkg.single-port-service",
-		"io.ksonnet.pkg.deployment-exposed-with-service",
+		"io.ksonnet.pkg.deployed-service",
 		"io.some-vendor.pkg.simple-service",
 	})
 	assertSearch(t, idx, Suffix, "simple", []string{})
@@ -131,7 +131,7 @@ func TestSearch(t *testing.T) {
 	// Substring searches.
 	assertSearch(t, idx, Substring, "service", []string{
 		"io.ksonnet.pkg.single-port-service",
-		"io.ksonnet.pkg.deployment-exposed-with-service",
+		"io.ksonnet.pkg.deployed-service",
 		"io.some-vendor.pkg.simple-service",
 	})
 	assertSearch(t, idx, Substring, "simple", []string{
@@ -139,7 +139,7 @@ func TestSearch(t *testing.T) {
 		"io.some-vendor.pkg.simple-service",
 	})
 	assertSearch(t, idx, Substring, "io.ksonnet", []string{
-		"io.ksonnet.pkg.deployment-exposed-with-service",
+		"io.ksonnet.pkg.deployed-service",
 		"io.ksonnet.pkg.single-port-service",
 		"io.ksonnet.pkg.single-port-deployment",
 		"io.ksonnet.pkg.configMap",

--- a/prototype/systemPrototypes.go
+++ b/prototype/systemPrototypes.go
@@ -56,9 +56,9 @@ will typically look something like:
 	},
 	&SpecificationSchema{
 		APIVersion: "0.1",
-		Name:       "io.ksonnet.pkg.deployment-exposed-with-service",
+		Name:       "io.ksonnet.pkg.deployed-service",
 		Params: ParamSchemas{
-			RequiredParam("name", "name", "Name of the service and deployment", String),
+			RequiredParam("name", "name", "Name of the service and deployment resources", String),
 			RequiredParam("image", "containerImage", "Container image to deploy", String),
 			OptionalParam("servicePort", "port", "Port for the service to expose.", "80", NumberOrString),
 			OptionalParam("containerPort", "port", "Container port for service to target.", "80", NumberOrString),


### PR DESCRIPTION
@hausdorff @jessicayuen PTAL

If it's clearer, I can split this into two PRs, but changes are:

* Changes to README based on Ruben and Joe's feedback
* Rename `deployment-exposed-with-service` prototype to `deployed-service`

Intended to fix https://github.com/ksonnet/ksonnet/issues/134 and https://github.com/ksonnet/ksonnet/issues/118