### PR TITLE
Fix segfault for ks diff

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -44,8 +44,11 @@ var diffCmd = &cobra.Command{
 	Use:   "diff [<env1> [<env2>]] [-f <file-or-dir>]",
 	Short: "Display differences between server and local config, or server and server config",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("'diff' requires at least one argument, that is the name of the environment\n\n%s", cmd.UsageString())
+		}
 		if len(args) > 2 {
-			return fmt.Errorf("'diff' takes at most two arguments, that are the name of the environments")
+			return fmt.Errorf("'diff' takes at most two arguments, that are the name of the environments\n\n%s", cmd.UsageString())
 		}
 
 		flags := cmd.Flags()


### PR DESCRIPTION
Output usage and return when no command args are provided for `ks diff`.

Fixes #158 