### PR TITLE
Use relative paths on jsonnet imports

### DIFF
--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -517,8 +517,12 @@ func (m *manager) generateKsonnetLibData(spec ClusterSpec) ([]byte, []byte, []by
 }
 
 func (m *manager) generateOverrideData() []byte {
+	const (
+		relBaseLibsonnetPath = "../" + baseLibsonnetFile
+	)
+
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("local base = import \"%s\";\n", m.baseLibsonnetPath))
+	buf.WriteString(fmt.Sprintf("local base = import \"%s\";\n", relBaseLibsonnetPath))
 	buf.WriteString(fmt.Sprintf("local k = import \"%s\";\n\n", extensionsLibFilename))
 	buf.WriteString("base + {\n")
 	buf.WriteString("  // Insert user-specified overrides here. For example if a component is named \"nginx-deployment\", you might have something like:\n")
@@ -528,7 +532,11 @@ func (m *manager) generateOverrideData() []byte {
 }
 
 func (m *manager) generateParamsData() []byte {
-	return []byte(`local params = import "` + m.componentParamsPath + `";
+	const (
+		relComponentParamsPath = "../../" + componentsDir + "/" + paramsFileName
+	)
+
+	return []byte(`local params = import "` + relComponentParamsPath + `";
 params + {
   components +: {
     // Insert component parameter overrides here. Ex:

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -265,7 +265,7 @@ func TestSetEnvironment(t *testing.T) {
 func TestGenerateOverrideData(t *testing.T) {
 	m := mockEnvironments(t, "test-gen-override-data")
 
-	expected := `local base = import "test-gen-override-data/environments/base.libsonnet";
+	expected := `local base = import "../base.libsonnet";
 local k = import "k.libsonnet";
 
 base + {
@@ -283,7 +283,7 @@ base + {
 func TestGenerateParamsData(t *testing.T) {
 	m := mockEnvironments(t, "test-gen-params-data")
 
-	expected := `local params = import "test-gen-params-data/components/params.libsonnet";
+	expected := `local params = import "../../components/params.libsonnet";
 params + {
   components +: {
     // Insert component parameter overrides here. Ex:


### PR DESCRIPTION
Currently absolute paths are being used for jsonnet imports. This makes
it difficult to share the files across different systems.

Fixes #149 