### PR TITLE
 Clarify errors for commands requiring subcommands

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -90,6 +91,9 @@ uniquely identifies the cluster.
 		  staging.jsonnet
           params.libsonnet`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
 		return fmt.Errorf("Command 'env' requires a subcommand\n\n%s", cmd.UsageString())
 	},
 }

--- a/cmd/param.go
+++ b/cmd/param.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -58,6 +59,9 @@ run:
     ks env --help
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
 		return fmt.Errorf("Command 'param' requires a subcommand\n\n%s", cmd.UsageString())
 	},
 }

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -49,11 +49,12 @@ var pkgCmd = &cobra.Command{
 }
 
 var pkgInstallCmd = &cobra.Command{
-	Use:   "install <registry>/<library>@<version>",
-	Short: `Install a package as a dependency in the current ksonnet application`,
+	Use:     "install <registry>/<library>@<version>",
+	Short:   `Install a package as a dependency in the current ksonnet application`,
+	Aliases: []string{"get"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return fmt.Errorf("Command 'pkg install' requires a single argument of the form <registry>/<library>@<version>")
+			return fmt.Errorf("Command requires a single argument of the form <registry>/<library>@<version>\n\n%s", cmd.UsageString())
 		}
 
 		registry, libID, name, version, err := parseDepSpec(cmd, args[0])

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -44,6 +44,9 @@ var pkgCmd = &cobra.Command{
 	Use:   "pkg",
 	Short: `Manage packages and dependencies for the current ksonnet project`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
 		return fmt.Errorf("Command 'pkg' requires a subcommand\n\n%s", cmd.UsageString())
 	},
 }

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -44,6 +44,9 @@ var prototypeCmd = &cobra.Command{
 	Use:   "prototype",
 	Short: `Instantiate, inspect, and get examples for ksonnet prototypes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
 		return fmt.Errorf("Command 'prototype' requires a subcommand\n\n%s", cmd.UsageString())
 	},
 	Long: `Manage, inspect, instantiate, and get examples for ksonnet prototypes.

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -20,6 +20,9 @@ var registryCmd = &cobra.Command{
 	Use:   "registry",
 	Short: `Manage registries for current project`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
 		return fmt.Errorf("Command 'registry' requires a subcommand\n\n%s", cmd.UsageString())
 	},
 	Long: `Manage and inspect ksonnet registries.


### PR DESCRIPTION
Currently, commands such as `ks env non-existent-subcommand` will output
an error `Command 'env' requires a subcommand`.

This is not helpful since the user may assume there is the subcommand
'non-existent-subcommand'. This commit will clarify the error messages
in this scenario.

Fixes #140 