### PR TITLE
pkg install: Use 'master' as refSpec where version isn't provided

### DIFF
--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -249,7 +249,10 @@ func parseDepSpec(cmd *cobra.Command, spec string) (registry, libID, name, versi
 	if len(split) > 2 {
 		return "", "", "", "", fmt.Errorf("Symbol '@' is only allowed once, at the end of the argument of the form <registry>/<library>@<version>")
 	}
-	version = split[len(split)-1]
+	version = ""
+	if len(split) == 2 {
+		version = split[1]
+	}
 
 	name, err = cmd.Flags().GetString(flagName)
 	if err != nil {

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -96,7 +96,7 @@ func Init(name string, rootPath AbsPath, spec ClusterSpec, serverURI, namespace 
 	// directory tree, in case the network call fails.
 	const (
 		defaultIncubatorRegName = "incubator"
-		defaultIncubatorURI     = "github.com/ksonnet/parts/tree/test-reg/" + defaultIncubatorRegName
+		defaultIncubatorURI     = "github.com/ksonnet/parts/tree/master/" + defaultIncubatorRegName
 	)
 
 	gh, err := makeGitHubRegistryManager(&app.RegistryRefSpec{

--- a/metadata/registry_managers.go
+++ b/metadata/registry_managers.go
@@ -152,10 +152,17 @@ func (gh *gitHubRegistryManager) ResolveLibrarySpec(libID, libRefSpec string) (*
 }
 
 func (gh *gitHubRegistryManager) ResolveLibrary(libID, libAlias, libRefSpec string, onFile registry.ResolveFile, onDir registry.ResolveDirectory) (*parts.Spec, *app.LibraryRefSpec, error) {
+	const (
+		defaultRefSpec = "master"
+	)
+
 	client := github.NewClient(nil)
 
 	// Resolve `version` (a git refspec) to a specific SHA.
 	ctx := context.Background()
+	if len(libRefSpec) == 0 {
+		libRefSpec = defaultRefSpec
+	}
 	resolvedSHA, _, err := client.Repositories.GetCommitSHA1(ctx, gh.org, gh.repo, libRefSpec, "")
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fixes #151 

Currently, if a version is not provided to the following `pkg install`
command

`../ks pkg install incubator/redis`

, the following error will occur:

`ERROR GET
https://api.github.com/repos/ksonnet/parts/commits/incubator/redis: 404
Not Found []`

This commit will pull in the latest package from master where the
version is not specified.

Also set the default repository ref to 'master' instead of 'test-reg'.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>