### PR TITLE
Generated component name is optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /kubecfg
+/ks
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -388,6 +388,15 @@ var prototypeUseCmd = &cobra.Command{
 			return fmt.Errorf("Command has too many arguments (takes a prototype name and a component name)\n\n%s", cmd.UsageString())
 		}
 
+		name, err := flags.GetString("name")
+		if err != nil {
+			return err
+		}
+
+		if name == "" {
+			flags.Set("name", componentName)
+		}
+
 		params, err := getParameters(proto, flags)
 		if err != nil {
 			return err


### PR DESCRIPTION
Use component name for param name if name parameter is omitted

In general, prototypes have a name param. To reduce duplication, use the component name for the name param if the name parameter is omitted. This will turn :

```
ks prototype use deployed-service guestbook-ui \
  --name guestbook-ui \
  --image alpinejay/dns-single-redis-guestbook:1.0 \
  --type LoadBalancer
```

into

```
ks prototype use deployed-service guestbook-ui \
  --image alpinejay/dns-single-redis-guestbook:1.0 \
  --type LoadBalancer
```

as the `--name` parameter will be inferred. If the operator wishes the name to be different, they can supply the name parameter:

```
ks prototype use deployed-service guestbook-ui \
  --name fancy-stuff \
  --image alpinejay/dns-single-redis-guestbook:1.0 \
  --type LoadBalancer
```

This PR also adds the `ks` binary to `.gitignore`.

Fixes #89