### PR TITLE
Fix for namespace flag not registering on init

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -32,8 +32,6 @@ const (
 	flagEnvServer    = "server"
 	flagEnvNamespace = "namespace"
 	flagEnvContext   = "context"
-
-	defaultNamespace = "default"
 )
 
 func init() {
@@ -328,6 +326,8 @@ func commonEnvFlags(flags *pflag.FlagSet) (server, namespace, context string, er
 }
 
 func resolveEnvFlags(flags *pflag.FlagSet) (string, string, error) {
+	defaultNamespace := "default"
+
 	server, ns, context, err := commonEnvFlags(flags)
 	if err != nil {
 		return "", "", err
@@ -335,7 +335,7 @@ func resolveEnvFlags(flags *pflag.FlagSet) (string, string, error) {
 
 	if server == "" {
 		// server is not provided -- use the context.
-		server, ns, err = resolveContext(context)
+		server, defaultNamespace, err = resolveContext(context)
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
Fixes #172 

There is a bug where the `default` environment was not using the
`--namespace` flag, even when set.

This is due to a path of execution error where `ns` is overriden during
`resolveContext`, so it will never be empty -- resulting in a check
failure in line 345.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>