### PR TITLE
[WIP]  Default to Kubernetes API v1.8.0

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -51,7 +51,7 @@ func init() {
 	envCmd.AddCommand(envSetCmd)
 
 	// TODO: We need to make this default to checking the `kubeconfig` file.
-	envAddCmd.PersistentFlags().String(flagAPISpec, "version:v1.7.0",
+	envAddCmd.PersistentFlags().String(flagAPISpec, "version:v1.8.0",
 		"Manually specify API version from OpenAPI schema, cluster, or Kubernetes version")
 
 	envSetCmd.PersistentFlags().String(flagEnvName, "",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -35,7 +35,7 @@ const (
 func init() {
 	RootCmd.AddCommand(initCmd)
 	// TODO: We need to make this default to checking the `kubeconfig` file.
-	initCmd.PersistentFlags().String(flagAPISpec, "version:v1.7.0",
+	initCmd.PersistentFlags().String(flagAPISpec, "version:v1.8.0",
 		"Manually specified Kubernetes API version. The corresponding OpenAPI spec is used to generate ksonnet's Kubernetes libraries")
 
 	bindClientGoFlags(initCmd)

--- a/docs/cli-reference/ks_env_add.md
+++ b/docs/cli-reference/ks_env_add.md
@@ -66,7 +66,7 @@ ks env add prod --server=https://ksonnet-1.us-west.elb.amazonaws.com
 ### Options
 
 ```
-      --api-spec string   Manually specify API version from OpenAPI schema, cluster, or Kubernetes version (default "version:v1.7.0")
+      --api-spec string   Manually specify API version from OpenAPI schema, cluster, or Kubernetes version (default "version:v1.8.0")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ks_init.md
+++ b/docs/cli-reference/ks_init.md
@@ -82,7 +82,7 @@ ks init app-name --dir=custom-location
 ### Options
 
 ```
-      --api-spec string                Manually specified Kubernetes API version. The corresponding OpenAPI spec is used to generate ksonnet's Kubernetes libraries (default "version:v1.7.0")
+      --api-spec string                Manually specified Kubernetes API version. The corresponding OpenAPI spec is used to generate ksonnet's Kubernetes libraries (default "version:v1.8.0")
       --as string                      Username to impersonate for the operation
       --certificate-authority string   Path to a cert. file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS


### PR DESCRIPTION
Bump up the default Kubernetes API version from 1.7 to 1.8

This is pending updates from @abiogenesis-now to support 1.8 in `ksonnet-lib`.

Related: #30 