### PR TITLE
Parse short description for prototypes

### DIFF
--- a/prototype/specification.go
+++ b/prototype/specification.go
@@ -18,11 +18,12 @@ import (
 //
 
 const (
-	apiVersionTag  = "@apiVersion"
-	nameTag        = "@name"
-	descriptionTag = "@description"
-	paramTag       = "@param"
-	optParamTag    = "@optionalParam"
+	apiVersionTag       = "@apiVersion"
+	nameTag             = "@name"
+	descriptionTag      = "@description"
+	shortDescriptionTag = "@shortDescription"
+	paramTag            = "@param"
+	optParamTag         = "@optionalParam"
 )
 
 func FromJsonnet(data string) (*SpecificationSchema, error) {
@@ -97,7 +98,7 @@ func FromJsonnet(data string) (*SpecificationSchema, error) {
 		openText = bytes.Buffer{}
 		openText.WriteString(strings.TrimSpace(split[1]))
 		switch split[0] {
-		case apiVersionTag, nameTag, descriptionTag, paramTag, optParamTag: // Do nothing.
+		case apiVersionTag, nameTag, descriptionTag, shortDescriptionTag, paramTag, optParamTag: // Do nothing.
 		default:
 			return nil, fmt.Errorf(`Line in prototype heading comment is formatted incorrectly; '%s' is not
 recognized as a tag. Only tags can begin lines, and text that is wrapped must
@@ -186,6 +187,11 @@ func (s *SpecificationSchema) addField(tag, text string) error {
 			return fmt.Errorf("Prototype heading comment has two '@description' fields")
 		}
 		s.Template.Description = text
+	case shortDescriptionTag:
+		if s.Template.ShortDescription != "" {
+			return fmt.Errorf("Prototype heading comment has two '@shortDescription' fields")
+		}
+		s.Template.ShortDescription = text
 	case paramTag:
 		// NOTE: There is usually more than one `@param`, so we don't
 		// check length here.


### PR DESCRIPTION
Turns out this is actually required for https://github.com/ksonnet/ksonnet/issues/182.

This code needs to be present for https://github.com/ksonnet/parts/pull/51 to actually do anything.

I tested this locally (by changing the registry reference for `incubator`) and it works:

<img width="730" alt="screen shot 2017-11-30 at 5 19 23 pm" src="https://user-images.githubusercontent.com/25401650/33463453-a52c9b04-d5f2-11e7-9cc2-09d7fb70b16a.png">

@jessicayuen PTAL thanks!!

Signed-off-by: Jessica Yao <jessica@heptio.com>