### PR TITLE
[docs] Remove (now optional) `--name` syntax from `ks generate` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ cd ks-example
 
 # Autogenerate a basic manifest
 ks generate deployed-service guestbook-ui \
-  --name guestbook \
   --image gcr.io/heptio-images/ks-guestbook-demo:0.1 \
   --type ClusterIP
 
@@ -83,16 +82,16 @@ ks generate deployed-service guestbook-ui \
 ks apply default
 ```
 
-Now there should be a Deployment and Service running on your cluster! Try accessing the `guestbook` service in your browser. (How you do this may depend on your cluster setup).
+Now there should be a Deployment and Service running on your cluster! Try accessing the `guestbook-ui` service in your browser. (How you do this may depend on your cluster setup).
 
 <details>
 <summary><i>If you are unsure what to do, we suggest using <code>kubectl proxy</code>.</i></summary>
 <pre>
-# Set up an API proxy so that you can access the guestbook service locally
+# Set up an API proxy so that you can access the 'guestbook-ui' service locally
 kubectl proxy > /dev/null &
 PROXY_PID=$!
-QUICKSTART_NAMESPACE=$(kubectl get svc guestbook -o jsonpath="{.metadata.namespace}")
-GUESTBOOK_SERVICE_URL=http://localhost:8001/api/v1/proxy/namespaces/$QUICKSTART_NAMESPACE/services/guestbook
+QUICKSTART_NAMESPACE=$(kubectl get svc guestbook-ui -o jsonpath="{.metadata.namespace}")
+GUESTBOOK_SERVICE_URL=http://localhost:8001/api/v1/proxy/namespaces/$QUICKSTART_NAMESPACE/services/guestbook-ui
 open $GUESTBOOK_SERVICE_URL
 </pre>
 </details>
@@ -122,7 +121,7 @@ Check out the webpage again in your browser (force-refresh to update the javascr
 ks delete default
 
 # There should be no guestbook service left running
-kubectl get svc guestbook
+kubectl get svc guestbook-ui
 ```
 
 *(If you ended up copying and pasting the `kubectl proxy` code above, make sure to clean up that process with `kill -9 $PROXY_PID`).*

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -340,6 +340,7 @@ var generateCmd = &cobra.Command{
 	DisableFlagParsing: prototypeUseCmd.DisableFlagParsing,
 	RunE:               prototypeUseCmd.RunE,
 	Long:               prototypeUseCmd.Long,
+	Example:            prototypeUseCmd.Example,
 }
 
 var prototypeUseCmd = &cobra.Command{
@@ -428,9 +429,10 @@ var prototypeUseCmd = &cobra.Command{
 	},
 	Long: `
 The ` + "`generate`" + ` command (aliased from ` + "`prototype use`" + `) generates Kubernetes-
-compatible, Jsonnet ` + `manifests for components in your ksonnet app. Each prototype
+compatible, Jsonnet ` + `manifests for components in your ksonnet app. Each component
 corresponds to a single manifest in the` + " `components/` " + `directory. This manifest
-can define one or more Kubernetes resources.
+can define one or more Kubernetes resources, and is generated from a ksonnet
+*prototype* (a customizable, reusable Kubernetes configuration snippet).
 
 1. The first argument, the **prototype name**, can either be fully qualified
 (e.g.` + " `io.ksonnet.pkg.single-port-service`" + `) or a partial match (e.g.` +
@@ -445,11 +447,13 @@ file` + " `components/nginx-depl.jsonnet` " + `. Note that by default ksonnet wi
 expand prototypes into Jsonnet files.
 
        ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
-         --name=nginx                                                    \
          --image=nginx
 
+  If the optional ` + "`--name`"  + ` tag is not specified, all Kubernetes API resources
+  declared by this prototype use this argument as their own ` + "`metadata.name`" + `
+
 3. Prototypes can be further customized by passing in **parameters** via additional
-command line flags, such as` + " `--name` " + `and` + " `--image` " + `in the example above. Note that
+command line flags, such as ` + " `--image` " + `in the example above. Note that
 different prototypes support their own unique flags.
 
 ### Related Commands
@@ -464,14 +468,16 @@ different prototypes support their own unique flags.
 # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment', using the
 # 'nginx' image. The expanded prototype is placed in
 # 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx-depl'.
 ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
-  --name=nginx                                                    \
   --image=nginx
 
 # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
-# suffix, 'deployment'. The expanded prototype is again placed in
-# 'components/nginx-depl.jsonnet'. NOTE: if you have imported another
-# prototype with this suffix, this may resolve ambiguously for you.
+# suffix, 'deployment'. (This works unless there is an ambiguity, e.g. another
+# prototype with 'deployment' in its name.) The expanded prototype is again
+# placed in 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx' instead of 'nginx-depl'
+# (due to --name).
 ks prototype use deployment nginx-depl \
   --name=nginx                         \
   --image=nginx`,

--- a/docs/cli-reference/ks_generate.md
+++ b/docs/cli-reference/ks_generate.md
@@ -7,9 +7,10 @@ Use the specified prototype to generate a component manifest
 
 
 The `generate` command (aliased from `prototype use`) generates Kubernetes-
-compatible, Jsonnet manifests for components in your ksonnet app. Each prototype
+compatible, Jsonnet manifests for components in your ksonnet app. Each component
 corresponds to a single manifest in the `components/` directory. This manifest
-can define one or more Kubernetes resources.
+can define one or more Kubernetes resources, and is generated from a ksonnet
+*prototype* (a customizable, reusable Kubernetes configuration snippet).
 
 1. The first argument, the **prototype name**, can either be fully qualified
 (e.g. `io.ksonnet.pkg.single-port-service`) or a partial match (e.g. `service`).
@@ -23,11 +24,13 @@ file `components/nginx-depl.jsonnet` . Note that by default ksonnet will
 expand prototypes into Jsonnet files.
 
        ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
-         --name=nginx                                                    \
          --image=nginx
 
+  If the optional `--name` tag is not specified, all Kubernetes API resources
+  declared by this prototype use this argument as their own `metadata.name`
+
 3. Prototypes can be further customized by passing in **parameters** via additional
-command line flags, such as `--name` and `--image` in the example above. Note that
+command line flags, such as  `--image` in the example above. Note that
 different prototypes support their own unique flags.
 
 ### Related Commands
@@ -41,6 +44,28 @@ different prototypes support their own unique flags.
 
 ```
 ks generate <prototype-name> <component-name> [type] [parameter-flags]
+```
+
+### Examples
+
+```
+
+# Instantiate prototype 'io.ksonnet.pkg.single-port-deployment', using the
+# 'nginx' image. The expanded prototype is placed in
+# 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx-depl'.
+ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
+  --image=nginx
+
+# Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
+# suffix, 'deployment'. (This works unless there is an ambiguity, e.g. another
+# prototype with 'deployment' in its name.) The expanded prototype is again
+# placed in 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx' instead of 'nginx-depl'
+# (due to --name).
+ks prototype use deployment nginx-depl \
+  --name=nginx                         \
+  --image=nginx
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ks_prototype_use.md
+++ b/docs/cli-reference/ks_prototype_use.md
@@ -7,9 +7,10 @@ Use the specified prototype to generate a component manifest
 
 
 The `generate` command (aliased from `prototype use`) generates Kubernetes-
-compatible, Jsonnet manifests for components in your ksonnet app. Each prototype
+compatible, Jsonnet manifests for components in your ksonnet app. Each component
 corresponds to a single manifest in the `components/` directory. This manifest
-can define one or more Kubernetes resources.
+can define one or more Kubernetes resources, and is generated from a ksonnet
+*prototype* (a customizable, reusable Kubernetes configuration snippet).
 
 1. The first argument, the **prototype name**, can either be fully qualified
 (e.g. `io.ksonnet.pkg.single-port-service`) or a partial match (e.g. `service`).
@@ -23,11 +24,13 @@ file `components/nginx-depl.jsonnet` . Note that by default ksonnet will
 expand prototypes into Jsonnet files.
 
        ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
-         --name=nginx                                                    \
          --image=nginx
 
+  If the optional `--name` tag is not specified, all Kubernetes API resources
+  declared by this prototype use this argument as their own `metadata.name`
+
 3. Prototypes can be further customized by passing in **parameters** via additional
-command line flags, such as `--name` and `--image` in the example above. Note that
+command line flags, such as  `--image` in the example above. Note that
 different prototypes support their own unique flags.
 
 ### Related Commands
@@ -50,14 +53,16 @@ ks prototype use <prototype-name> <componentName> [type] [parameter-flags]
 # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment', using the
 # 'nginx' image. The expanded prototype is placed in
 # 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx-depl'.
 ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
-  --name=nginx                                                    \
   --image=nginx
 
 # Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
-# suffix, 'deployment'. The expanded prototype is again placed in
-# 'components/nginx-depl.jsonnet'. NOTE: if you have imported another
-# prototype with this suffix, this may resolve ambiguously for you.
+# suffix, 'deployment'. (This works unless there is an ambiguity, e.g. another
+# prototype with 'deployment' in its name.) The expanded prototype is again
+# placed in 'components/nginx-depl.jsonnet'.
+# The associated Deployment has metadata.name 'nginx' instead of 'nginx-depl'
+# (due to --name).
 ks prototype use deployment nginx-depl \
   --name=nginx                         \
   --image=nginx

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,6 @@
 
 If you get an error saying something to the effect of `403 API rate limit of 60 still exceeded` you can work around that by getting a Github personal access token and setting it up so that `ks` can use it.  Github has higher rate limits for authenticated users than unauthenticated users.
 
-1. Go to https://github.com/settings/tokens and generate a new token. You don't have to give it any access at all as you are simply authenticating.
+1. Go to [https://github.com/settings/tokens](https://github.com/settings/tokens) and generate a new token. You don't have to give it any access at all as you are simply authenticating.
 2. Make sure you save that token someplace because you can't see it again.  If you lose it you'll have to delete and create a new one.
 3. Set an environment variable in your shell: `export GITHUB_TOKEN=<token>`.  You may want to do this as part of your shell startup scripts (i.e. `.profile`).


### PR DESCRIPTION
@jessicayuen @bryanl PTAL thanks!

This PR addresses part of https://github.com/ksonnet/ksonnet/issues/194.

Signed-off-by: Jessica Yao <jessica@heptio.com>