### PR TITLE
Accurately read/write non-ASCII param identifiers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,8 +27,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ksonnet/ksonnet/metadata/params"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	log "github.com/sirupsen/logrus"
@@ -480,7 +478,7 @@ func constructBaseObj(componentPaths, componentNames []string) (string, error) {
 
 		// Emit object field. Sanitize the name to guarantee we generate valid
 		// Jsonnet.
-		componentName = params.SanitizeComponent(componentName)
+		componentName = utils.QuoteNonASCII(componentName)
 		fmt.Fprintf(&obj, "  %s: %s,\n", componentName, importExpr)
 	}
 

--- a/metadata/params/params_test.go
+++ b/metadata/params/params_test.go
@@ -275,11 +275,11 @@ func TestGetComponentParams(t *testing.T) {
     },
     foo: {
       name: "foo",
-      replicas: 1,
+      "replica-count": 1,
     },
   },
 }`,
-			Params{"name": `"foo"`, "replicas": "1"},
+			Params{"name": `"foo"`, "replica-count": "1"},
 		},
 		// Test getting the parameters for a component name with special characters
 		{
@@ -523,6 +523,30 @@ func TestSetComponentParams(t *testing.T) {
   },
 }`,
 		},
+		// Test adding a parameter with special characters in the param name
+		{
+			"foo",
+			`
+{
+  components: {
+    foo: {
+      "foo-bar": 5,
+      name: "foo",
+    },
+  },
+}`,
+			Params{"replica-count": "5"},
+			`
+{
+  components: {
+    foo: {
+      "foo-bar": 5,
+      name: "foo",
+      "replica-count": 5,
+    },
+  },
+}`,
+		},
 		// Test setting parameter for a component with a special character in name
 		{
 			"foo-bar",
@@ -700,13 +724,13 @@ params + {
     },
     "foo" +: {
       name: "foo",
-      replicas: 5,
+      "replica-count": 5,
     },
   },
 }`,
 			map[string]Params{
 				"bar": Params{"name": `"bar"`, "replicas": "1"},
-				"foo": Params{"name": `"foo"`, "replicas": "5"},
+				"foo": Params{"name": `"foo"`, "replica-count": "5"},
 			},
 		},
 	}
@@ -813,6 +837,38 @@ params + {
       |||,
       name: "foobar",
       replicas: 5,
+    },
+  },
+}`,
+		},
+		// Test special character in param identifier
+		{
+			"foo",
+			`
+local params = import "/fake/path";
+params + {
+  components +: {
+    bar +: {
+      name: "bar",
+      "replica-count": 1,
+    },
+    foo +: {
+      name: "foo",
+    },
+  },
+}`,
+			Params{"replica-count": "5"},
+			`
+local params = import "/fake/path";
+params + {
+  components +: {
+    bar +: {
+      name: "bar",
+      "replica-count": 1,
+    },
+    foo +: {
+      name: "foo",
+      "replica-count": 5,
     },
   },
 }`,

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -17,6 +17,7 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/PuerkitoBio/purell"
@@ -32,6 +33,15 @@ func IsASCIIIdentifier(s string) bool {
 		return false
 	}
 	return true
+}
+
+// QuoteNonASCII puts quotes around an identifier that contains non-ASCII
+// characters.
+func QuoteNonASCII(s string) string {
+	if !IsASCIIIdentifier(s) {
+		return fmt.Sprintf(`"%s"`, s)
+	}
+	return s
 }
 
 // NormalizeURL uses purell's "usually safe normalization" algorithm to

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -53,6 +53,37 @@ func TestIsASCIIIdentifier(t *testing.T) {
 	}
 }
 
+func TestQuoteNonASCII(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "HelloWorld",
+			expected: "HelloWorld",
+		},
+		{
+			input:    "Hello World",
+			expected: `"Hello World"`,
+		},
+		{
+			input:    "helloworld",
+			expected: "helloworld",
+		},
+		{
+			input:    "hello-world",
+			expected: `"hello-world"`,
+		},
+		{
+			input:    "hello世界",
+			expected: `"hello世界"`,
+		},
+	}
+	for _, test := range tests {
+		require.EqualValues(t, test.expected, QuoteNonASCII(test.input))
+	}
+}
+
 func TestNormalizeURL(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
**Fixes #214**

Currently, if we run `param set guestbook-ui foo-bar x`,

The jsonnet snippet will write: `foo-bar: "x"`.

However, this is incorrect jsonnet syntax. This commit will fix this
issue, to instead write `"foo-bar": "x"`.

Also updates the `Get...` Param functions to return non-quoted
identifiers for prettier display.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>