### PR TITLE
Implement command `ks registry add`

### DIFF
--- a/docs/cli-reference/ks_registry.md
+++ b/docs/cli-reference/ks_registry.md
@@ -35,6 +35,7 @@ ks registry
 
 ### SEE ALSO
 * [ks](ks.md)	 - Configure your application to deploy to a Kubernetes cluster
+* [ks registry add](ks_registry_add.md)	 - Add a registry to the current ksonnet app
 * [ks registry describe](ks_registry_describe.md)	 - Describe a ksonnet registry and the packages it contains
 * [ks registry list](ks_registry_list.md)	 - List all registries known to the current ksonnet app.
 

--- a/docs/cli-reference/ks_registry_add.md
+++ b/docs/cli-reference/ks_registry_add.md
@@ -1,0 +1,59 @@
+## ks registry add
+
+Add a registry to the current ksonnet app
+
+### Synopsis
+
+
+
+The `add` command allows custom registries to be added to your ksonnet app.
+
+A registry is uniquely identified by its:
+
+1. Name
+2. Version
+
+Currently, only registries supporting the GitHub protocol can be added.
+
+All registries must specify a unique name and URI where the registry lives.
+Optionally, a version can be provided. If a version is not specified, it will
+default to  `latest`.
+
+
+### Related Commands
+
+* `ks registry list` — List all registries known to the current ksonnet app.
+
+### Syntax
+
+
+```
+ks registry add <registry-name> <registry-uri>
+```
+
+### Examples
+
+```
+# Add a registry with the name 'databases' at the uri 'github.com/example'
+ks registry add databases github.com/example
+
+# Add a registry with the name 'databases' at the uri 'github.com/example' and
+# the version 0.0.1
+ks registry add databases github.com/example --version=0.0.1
+```
+
+### Options
+
+```
+      --version string   Version of the registry to add
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
+```
+
+### SEE ALSO
+* [ks registry](ks_registry.md)	 - Manage registries for current project
+

--- a/pkg/kubecfg/registry.go
+++ b/pkg/kubecfg/registry.go
@@ -1,0 +1,44 @@
+// Copyright 2017 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+// RegistryAddCmd contains the metadata needed to create a registry.
+type RegistryAddCmd struct {
+	name     string
+	protocol string
+	uri      string
+	version  string
+}
+
+// NewRegistryAddCmd initializes a RegistryAddCmd.
+func NewRegistryAddCmd(name, protocol, uri, version string) *RegistryAddCmd {
+	if version == "" {
+		version = "latest"
+	}
+
+	return &RegistryAddCmd{name: name, protocol: protocol, uri: uri, version: version}
+}
+
+// Run adds the registry to the ksonnet project.
+func (c *RegistryAddCmd) Run() error {
+	manager, err := manager()
+	if err != nil {
+		return err
+	}
+
+	_, err = manager.AddRegistry(c.name, c.protocol, c.uri, c.version)
+	return err
+}


### PR DESCRIPTION
Fixes #226

Currently users are unable to add their own registries through the CLI.
This limits them to a small subset of prototypes found in the default
incubator registry.

This commit will add the command `ks registry add`, that allows users to
add registries supporting the `github` protocol.

It will be of the form `ks registry add <registry-name> <registry-uri>
[--version]`. If a version is not specified, `latest` will be used.