### PR TITLE
Allow the default registry to be configured via environment variable.

### DIFF
--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -96,8 +96,12 @@ func Init(name string, rootPath AbsPath, spec ClusterSpec, serverURI, namespace 
 	// directory tree, in case the network call fails.
 	const (
 		defaultIncubatorRegName = "incubator"
-		defaultIncubatorURI     = "github.com/ksonnet/parts/tree/master/" + defaultIncubatorRegName
 	)
+
+	defaultIncubatorURI := os.Getenv("KSONNET_DEFAULT_REGISTRY");
+	if defaultIncubatorURI == "" {
+		defaultIncubatorURI = "github.com/ksonnet/parts/tree/master/" + defaultIncubatorRegName;
+	};
 
 	gh, err := makeGitHubRegistryManager(&app.RegistryRefSpec{
 		Name:     "incubator",


### PR DESCRIPTION
* This unblocks projects (like [Kubeflow](google/kubeflow)) that want to start using their
  own registry.