### PR TITLE
Add command 'component list'

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -1,0 +1,64 @@
+// Copyright 2017 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ksonnet/ksonnet/pkg/kubecfg"
+)
+
+func init() {
+	RootCmd.AddCommand(componentCmd)
+
+	componentCmd.AddCommand(componentListCmd)
+}
+
+var componentCmd = &cobra.Command{
+	Use:   "component",
+	Short: "Manage ksonnet components",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("%s is not a valid subcommand\n\n%s", strings.Join(args, " "), cmd.UsageString())
+		}
+		return fmt.Errorf("Command 'component' requires a subcommand\n\n%s", cmd.UsageString())
+	},
+}
+
+var componentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List known components",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("'component list' takes zero arguments")
+		}
+
+		c := kubecfg.NewComponentListCmd()
+
+		return c.Run(cmd.OutOrStdout())
+	},
+	Long: `
+The ` + "`list`" + ` command displays all known components.
+
+### Syntax
+`,
+	Example: `
+# List all components
+ks component list`,
+}

--- a/docs/cli-reference/ks.md
+++ b/docs/cli-reference/ks.md
@@ -20,6 +20,7 @@ application configuration to remote clusters.
 
 ### SEE ALSO
 * [ks apply](ks_apply.md)	 - Apply local Kubernetes manifests (components) to remote clusters
+* [ks component](ks_component.md)	 - Manage ksonnet components
 * [ks delete](ks_delete.md)	 - Remove component-specified Kubernetes resources from remote clusters
 * [ks diff](ks_diff.md)	 - Compare manifests, based on environment or location (local or remote)
 * [ks env](ks_env.md)	 - Manage ksonnet environments

--- a/docs/cli-reference/ks_component.md
+++ b/docs/cli-reference/ks_component.md
@@ -1,0 +1,23 @@
+## ks component
+
+Manage ksonnet components
+
+### Synopsis
+
+
+Manage ksonnet components
+
+```
+ks component
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
+```
+
+### SEE ALSO
+* [ks](ks.md)	 - Configure your application to deploy to a Kubernetes cluster
+* [ks component list](ks_component_list.md)	 - List known components
+

--- a/docs/cli-reference/ks_component_list.md
+++ b/docs/cli-reference/ks_component_list.md
@@ -1,0 +1,34 @@
+## ks component list
+
+List known components
+
+### Synopsis
+
+
+
+The `list` command displays all known components.
+
+### Syntax
+
+
+```
+ks component list
+```
+
+### Examples
+
+```
+
+# List all components
+ks component list
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
+```
+
+### SEE ALSO
+* [ks component](ks_component.md)	 - Manage ksonnet components
+

--- a/metadata/component.go
+++ b/metadata/component.go
@@ -1,0 +1,79 @@
+// Copyright 2017 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	param "github.com/ksonnet/ksonnet/metadata/params"
+	"github.com/ksonnet/ksonnet/prototype"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func (m *manager) ComponentPaths() (AbsPaths, error) {
+	paths := AbsPaths{}
+	err := afero.Walk(m.appFS, string(m.componentsPath), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+func (m *manager) CreateComponent(name string, text string, params param.Params, templateType prototype.TemplateType) error {
+	if !isValidName(name) || strings.Contains(name, "/") {
+		return fmt.Errorf("Component name '%s' is not valid; must not contain punctuation, spaces, or begin or end with a slash", name)
+	}
+
+	componentPath := string(appendToAbsPath(m.componentsPath, name))
+	switch templateType {
+	case prototype.YAML:
+		componentPath = componentPath + ".yaml"
+	case prototype.JSON:
+		componentPath = componentPath + ".json"
+	case prototype.Jsonnet:
+		componentPath = componentPath + ".jsonnet"
+	default:
+		return fmt.Errorf("Unrecognized prototype template type '%s'", templateType)
+	}
+
+	if exists, err := afero.Exists(m.appFS, componentPath); exists {
+		return fmt.Errorf("Component with name '%s' already exists", name)
+	} else if err != nil {
+		return fmt.Errorf("Could not check whether component '%s' exists:\n\n%v", name, err)
+	}
+
+	log.Infof("Writing component at '%s/%s'", componentsDir, name)
+	err := afero.WriteFile(m.appFS, componentPath, []byte(text), defaultFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Writing component parameters at '%s/%s", componentsDir, name)
+	return m.writeComponentParams(name, params)
+}

--- a/metadata/component_test.go
+++ b/metadata/component_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+)
+
+func TestComponentPaths(t *testing.T) {
+	spec, err := parseClusterSpec(fmt.Sprintf("file:%s", blankSwagger), testFS)
+	if err != nil {
+		t.Fatalf("Failed to parse cluster spec: %v", err)
+	}
+
+	appPath := AbsPath("/componentPaths")
+	reg := newMockRegistryManager("incubator")
+	m, err := initManager("componentPaths", appPath, spec, &mockAPIServer, &mockNamespace, reg, testFS)
+	if err != nil {
+		t.Fatalf("Failed to init cluster spec: %v", err)
+	}
+
+	// Create empty app file.
+	components := appendToAbsPath(appPath, componentsDir)
+	appFile1 := appendToAbsPath(components, "component1.jsonnet")
+	f1, err := testFS.OpenFile(string(appFile1), os.O_RDONLY|os.O_CREATE, 0777)
+	if err != nil {
+		t.Fatalf("Failed to touch app file '%s'\n%v", appFile1, err)
+	}
+	f1.Close()
+
+	// Create empty file in a nested directory.
+	appSubdir := appendToAbsPath(components, "appSubdir")
+	err = testFS.MkdirAll(string(appSubdir), os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create directory '%s'\n%v", appSubdir, err)
+	}
+	appFile2 := appendToAbsPath(appSubdir, "component2.jsonnet")
+	f2, err := testFS.OpenFile(string(appFile2), os.O_RDONLY|os.O_CREATE, 0777)
+	if err != nil {
+		t.Fatalf("Failed to touch app file '%s'\n%v", appFile1, err)
+	}
+	f2.Close()
+
+	// Create a directory that won't be listed in the call to `ComponentPaths`.
+	unlistedDir := string(appendToAbsPath(components, "doNotListMe"))
+	err = testFS.MkdirAll(unlistedDir, os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create directory '%s'\n%v", unlistedDir, err)
+	}
+
+	paths, err := m.ComponentPaths()
+	if err != nil {
+		t.Fatalf("Failed to find component paths: %v", err)
+	}
+
+	sort.Slice(paths, func(i, j int) bool { return paths[i] < paths[j] })
+
+	if len(paths) != 3 || paths[0] != string(appFile2) || paths[1] != string(appFile1) {
+		t.Fatalf("m.ComponentPaths failed; expected '%s', got '%s'", []string{string(appFile1), string(appFile2)}, paths)
+	}
+}

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -49,6 +49,7 @@ type Manager interface {
 
 	// Components API.
 	ComponentPaths() (AbsPaths, error)
+	GetAllComponents() ([]string, error)
 	CreateComponent(name string, text string, params param.Params, templateType prototype.TemplateType) error
 
 	// Params API.

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"sort"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -205,60 +204,6 @@ func TestFindSuccess(t *testing.T) {
 	f.Close()
 
 	findSuccess(t, appPath, appFile)
-}
-
-func TestComponentPaths(t *testing.T) {
-	spec, err := parseClusterSpec(fmt.Sprintf("file:%s", blankSwagger), testFS)
-	if err != nil {
-		t.Fatalf("Failed to parse cluster spec: %v", err)
-	}
-
-	appPath := AbsPath("/componentPaths")
-	reg := newMockRegistryManager("incubator")
-	m, err := initManager("componentPaths", appPath, spec, &mockAPIServer, &mockNamespace, reg, testFS)
-	if err != nil {
-		t.Fatalf("Failed to init cluster spec: %v", err)
-	}
-
-	// Create empty app file.
-	components := appendToAbsPath(appPath, componentsDir)
-	appFile1 := appendToAbsPath(components, "component1.jsonnet")
-	f1, err := testFS.OpenFile(string(appFile1), os.O_RDONLY|os.O_CREATE, 0777)
-	if err != nil {
-		t.Fatalf("Failed to touch app file '%s'\n%v", appFile1, err)
-	}
-	f1.Close()
-
-	// Create empty file in a nested directory.
-	appSubdir := appendToAbsPath(components, "appSubdir")
-	err = testFS.MkdirAll(string(appSubdir), os.ModePerm)
-	if err != nil {
-		t.Fatalf("Failed to create directory '%s'\n%v", appSubdir, err)
-	}
-	appFile2 := appendToAbsPath(appSubdir, "component2.jsonnet")
-	f2, err := testFS.OpenFile(string(appFile2), os.O_RDONLY|os.O_CREATE, 0777)
-	if err != nil {
-		t.Fatalf("Failed to touch app file '%s'\n%v", appFile1, err)
-	}
-	f2.Close()
-
-	// Create a directory that won't be listed in the call to `ComponentPaths`.
-	unlistedDir := string(appendToAbsPath(components, "doNotListMe"))
-	err = testFS.MkdirAll(unlistedDir, os.ModePerm)
-	if err != nil {
-		t.Fatalf("Failed to create directory '%s'\n%v", unlistedDir, err)
-	}
-
-	paths, err := m.ComponentPaths()
-	if err != nil {
-		t.Fatalf("Failed to find component paths: %v", err)
-	}
-
-	sort.Slice(paths, func(i, j int) bool { return paths[i] < paths[j] })
-
-	if len(paths) != 3 || paths[0] != string(appFile2) || paths[1] != string(appFile1) {
-		t.Fatalf("m.ComponentPaths failed; expected '%s', got '%s'", []string{string(appFile1), string(appFile2)}, paths)
-	}
 }
 
 func TestLibPaths(t *testing.T) {

--- a/pkg/kubecfg/component.go
+++ b/pkg/kubecfg/component.go
@@ -1,0 +1,73 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/ksonnet/ksonnet/utils"
+)
+
+const (
+	componentNameHeader = "COMPONENT"
+)
+
+// ComponentListCmd stores the information necessary to display components.
+type ComponentListCmd struct {
+}
+
+// NewComponentListCmd acts as a constructor for ComponentListCmd.
+func NewComponentListCmd() *ComponentListCmd {
+	return &ComponentListCmd{}
+}
+
+// Run executes the displaying of components.
+func (c *ComponentListCmd) Run(out io.Writer) error {
+	manager, err := manager()
+	if err != nil {
+		return err
+	}
+
+	components, err := manager.GetAllComponents()
+	if err != nil {
+		return err
+	}
+
+	_, err = printComponents(out, components)
+	return err
+}
+
+func printComponents(out io.Writer, components []string) (string, error) {
+	rows := [][]string{
+		[]string{componentNameHeader},
+		[]string{strings.Repeat("=", len(componentNameHeader))},
+	}
+
+	sort.Strings(components)
+	for _, component := range components {
+		rows = append(rows, []string{component})
+	}
+
+	formatted, err := utils.PadRows(rows)
+	if err != nil {
+		return "", err
+	}
+	_, err = fmt.Fprint(out, formatted)
+	return formatted, err
+}

--- a/pkg/kubecfg/component_test.go
+++ b/pkg/kubecfg/component_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintComponents(t *testing.T) {
+	for _, tc := range []struct {
+		components []string
+		expected   string
+	}{
+		{
+			components: []string{"a", "b"},
+			expected: `COMPONENT
+=========
+a
+b
+`,
+		},
+		// Check that components are displayed in alphabetical order
+		{
+			components: []string{"b", "a"},
+			expected: `COMPONENT
+=========
+a
+b
+`,
+		},
+		// Check empty components scenario
+		{
+			components: []string{},
+			expected: `COMPONENT
+=========
+`,
+		},
+	} {
+		out, err := printComponents(os.Stdout, tc.components)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		require.EqualValues(t, tc.expected, out)
+	}
+}


### PR DESCRIPTION
Fixes #242 

This adds a high level 'component' command and a 'component list'
command. 'component list' will pretty print all the components in
ksonnet application directory.

To accomplish this, an API is added to the metadata manager that returns
all components. Components are the individual files in /components, with
the path extension trimmed.

@abiogenesis-now Going to add this to your radar since you may want to update the docs once this is merged! The command docs for this command are currently very trivial.