### PR TITLE
Clarify error message for duplicate packages on install

### DIFF
--- a/metadata/registry.go
+++ b/metadata/registry.go
@@ -151,7 +151,7 @@ func (m *manager) CacheDependency(registryName, libID, libName, libVersion strin
 	}
 
 	if _, ok := appSpec.Libraries[libName]; ok {
-		return nil, fmt.Errorf("Library '%s' already exists", libName)
+		return nil, fmt.Errorf("Package '%s' already exists. Use the --name flag to install this package with a unique identifier", libName)
 	}
 
 	// Retrieve registry manager for this specific registry.


### PR DESCRIPTION
Fixes #269 

Consider the scenario where the user has two registries 'incubator', and
'incubatorXYZ' pointing to the same repository.

It might be confusing why running `ks pkg install incubatorXYZ/mysql`
fails if they ran `ks pkg install incubator/mysql` previously.

This is a small change to help users resolve that scenario by passing
the `--name` flag on install.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>
  