### PR TITLE
Implement explicit env metadata

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -315,7 +315,8 @@ func expandEnvObjs(cmd *cobra.Command, env string, manager metadata.Manager) ([]
 		return nil, err
 	}
 
-	libPath, vendorPath, envLibPath, envComponentPath, envParamsPath := manager.LibPaths(env)
+	libPath, vendorPath := manager.LibPaths()
+	metadataPath, mainPath, paramsPath, specPath := manager.EnvPaths(env)
 	componentPaths, err := manager.ComponentPaths()
 	if err != nil {
 		return nil, err
@@ -325,12 +326,13 @@ func expandEnvObjs(cmd *cobra.Command, env string, manager metadata.Manager) ([]
 	if err != nil {
 		return nil, err
 	}
-	params := importParams(string(envParamsPath))
+	params := importParams(string(paramsPath))
+	spec := importEnv(string(specPath))
 
-	expander.FlagJpath = append([]string{string(libPath), string(vendorPath), string(envLibPath)}, expander.FlagJpath...)
-	expander.ExtCodes = append([]string{baseObj, params}, expander.ExtCodes...)
+	expander.FlagJpath = append([]string{string(libPath), string(vendorPath), string(metadataPath)}, expander.FlagJpath...)
+	expander.ExtCodes = append([]string{baseObj, params, spec}, expander.ExtCodes...)
 
-	envFiles := []string{string(envComponentPath)}
+	envFiles := []string{string(mainPath)}
 
 	return expander.Expand(envFiles)
 }

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -449,7 +449,7 @@ expand prototypes into Jsonnet files.
        ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
          --image=nginx
 
-  If the optional ` + "`--name`"  + ` tag is not specified, all Kubernetes API resources
+  If the optional ` + "`--name`" + ` tag is not specified, all Kubernetes API resources
   declared by this prototype use this argument as their own ` + "`metadata.name`" + `
 
 3. Prototypes can be further customized by passing in **parameters** via additional
@@ -503,7 +503,10 @@ func expandPrototype(proto *prototype.SpecificationSchema, templateType prototyp
 		if !utils.IsASCIIIdentifier(componentName) {
 			componentsText = fmt.Sprintf(`components["%s"]`, componentName)
 		}
-		template = append([]string{`local params = std.extVar("` + metadata.ParamsExtCodeKey + `").` + componentsText + ";"}, template...)
+		template = append([]string{
+			`local env = std.extVar("` + metadata.EnvExtCodeKey + `");`,
+			`local params = std.extVar("` + metadata.ParamsExtCodeKey + `").` + componentsText + ";"},
+			template...)
 		return jsonnet.Parse(componentName, strings.Join(template, "\n"))
 	}
 

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -45,7 +45,8 @@ type AbsPaths []string
 // libraries; and other non-core-application tasks.
 type Manager interface {
 	Root() AbsPath
-	LibPaths(envName string) (libPath, vendorPath, envLibPath, envComponentPath, envParamsPath AbsPath)
+	LibPaths() (libPath, vendorPath AbsPath)
+	EnvPaths(env string) (metadataPath, mainPath, paramsPath, specPath AbsPath)
 
 	// Components API.
 	ComponentPaths() (AbsPaths, error)

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -51,7 +51,9 @@ const (
 
 	// ComponentsExtCodeKey is the ExtCode key for component imports
 	ComponentsExtCodeKey = "__ksonnet/components"
-	// ParamsExtCodeKey is the ExtCode key for importing environment parameters
+	// EnvExtCodeKey is the ExtCode key for importing environment metadata
+	EnvExtCodeKey = "__ksonnet/environments"
+	// ParamsExtCodeKey is the ExtCode key for importing component parameters
 	ParamsExtCodeKey = "__ksonnet/params"
 
 	// User-level ksonnet directories.
@@ -197,10 +199,23 @@ func (m *manager) Root() AbsPath {
 	return m.rootPath
 }
 
-func (m *manager) LibPaths(envName string) (libPath, vendorPath, envLibPath, envComponentPath, envParamsPath AbsPath) {
-	envPath := appendToAbsPath(m.environmentsPath, envName)
-	return m.libPath, m.vendorPath, appendToAbsPath(envPath, metadataDirName),
-		appendToAbsPath(envPath, envFileName), appendToAbsPath(envPath, componentParamsFile)
+func (m *manager) LibPaths() (libPath, vendorPath AbsPath) {
+	return m.libPath, m.vendorPath
+}
+
+func (m *manager) EnvPaths(env string) (metadataPath, mainPath, paramsPath, specPath AbsPath) {
+	envPath := appendToAbsPath(m.environmentsPath, env)
+
+	// .metadata directory
+	metadataPath = appendToAbsPath(envPath, metadataDirName)
+	// main.jsonnet file
+	mainPath = appendToAbsPath(envPath, envFileName)
+	// params.libsonnet file
+	paramsPath = appendToAbsPath(envPath, componentParamsFile)
+	// spec.json file
+	specPath = appendToAbsPath(envPath, specFilename)
+
+	return
 }
 
 func (m *manager) GetComponentParams(component string) (param.Params, error) {

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -210,26 +210,38 @@ func TestLibPaths(t *testing.T) {
 	appName := "test-lib-paths"
 	expectedVendorPath := path.Join(appName, vendorDir)
 	expectedLibPath := path.Join(appName, libDir)
-	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
-	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, envFileName)
-	expectedEnvParamsPath := path.Join(appName, environmentsDir, mockEnvName, paramsFileName)
 	m := mockEnvironments(t, appName)
 
-	libPath, vendorPath, envLibPath, envComponentPath, envParamsPath := m.LibPaths(mockEnvName)
+	libPath, vendorPath := m.LibPaths()
 	if string(libPath) != expectedLibPath {
 		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
 	}
 	if string(vendorPath) != expectedVendorPath {
 		t.Fatalf("Expected vendor lib path to be:\n  '%s'\n, got:\n  '%s'", expectedVendorPath, vendorPath)
 	}
-	if string(envLibPath) != expectedEnvLibPath {
-		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)
+}
+
+func TestEnvPaths(t *testing.T) {
+	appName := "test-env-paths"
+	expectedMetadataPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
+	expectedMainPath := path.Join(appName, environmentsDir, mockEnvName, envFileName)
+	expectedParamsPath := path.Join(appName, environmentsDir, mockEnvName, paramsFileName)
+	expectedSpecPath := path.Join(appName, environmentsDir, mockEnvName, specFilename)
+	m := mockEnvironments(t, appName)
+
+	metadataPath, mainPath, paramsPath, specPath := m.EnvPaths(mockEnvName)
+
+	if string(metadataPath) != expectedMetadataPath {
+		t.Fatalf("Expected environment metadata dir path to be:\n  '%s'\n, got:\n  '%s'", expectedMetadataPath, metadataPath)
 	}
-	if string(envComponentPath) != expectedEnvComponentPath {
-		t.Fatalf("Expected environment component path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvComponentPath, envComponentPath)
+	if string(mainPath) != expectedMainPath {
+		t.Fatalf("Expected environment main path to be:\n  '%s'\n, got:\n  '%s'", expectedMainPath, mainPath)
 	}
-	if string(envParamsPath) != expectedEnvParamsPath {
-		t.Fatalf("Expected environment params path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvParamsPath, envParamsPath)
+	if string(paramsPath) != expectedParamsPath {
+		t.Fatalf("Expected environment params path to be:\n  '%s'\n, got:\n  '%s'", expectedParamsPath, paramsPath)
+	}
+	if string(specPath) != expectedSpecPath {
+		t.Fatalf("Expected environment spec path to be:\n  '%s'\n, got:\n  '%s'", expectedSpecPath, specPath)
 	}
 }
 

--- a/prototype/snippet/jsonnet/snippet_test.go
+++ b/prototype/snippet/jsonnet/snippet_test.go
@@ -135,6 +135,32 @@ func TestParse(t *testing.T) {
 			`local f = f;
 			{ foo: f, }`,
 		},
+		// Test where there are multiple import types.
+		{
+			`
+			local k = import 'ksonnet.beta.2/k.libsonnet';
+			
+			local service = k.core.v1.service;
+			local servicePort = k.core.v1.service.mixin.spec.portsType;
+			local port = servicePort.new((import 'param://port'), (import 'param://portName'));
+			
+			local namespace = import 'env://namespace';
+			
+			local name = import 'param://name';
+			k.core.v1.service.new('%s-service' % [name], {app: name}, port)`,
+
+			`
+			local k = import 'ksonnet.beta.2/k.libsonnet';
+			
+			local service = k.core.v1.service;
+			local servicePort = k.core.v1.service.mixin.spec.portsType;
+			local port = servicePort.new((params.port), (params.portName));
+			
+			local namespace = env.namespace;
+			
+			local name = params.name;
+			k.core.v1.service.new('%s-service' % [name], {app: name}, port)`,
+		},
 	}
 
 	errors := []string{


### PR DESCRIPTION
Partially implements the proposal [here](https://github.com/ksonnet/ksonnet/blob/master/design/proposals/explicit-environment-metadata.md).

Version 2 of prototypes in the parts library that follow the historical model of hard-coded namespaces will be updated subsequently. This change does not break existing prototypes.

Fixes #222

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>