### PR TITLE
Removing realpath

### DIFF
--- a/docs/generate/update-generated-docs.sh
+++ b/docs/generate/update-generated-docs.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KSONNET_ROOT=$(realpath $(dirname ${BASH_SOURCE})/../..)
+KSONNET_ROOT=$(cd "$(dirname "$0")/../.."; pwd)
+
 BIN=${KSONNET_ROOT}/_output/bin
 mkdir -p ${BIN}
 go build -o ${BIN}/docs-gen ./docs/generate/ks.go


### PR DESCRIPTION
Darwin (Mac OS systems) does not ship with `realpath` by default

So this removes the `realpath` reference so `make` works out of the box