### PR TITLE
Construct apimachinery version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,11 @@
 VERSION?=dev-$(shell date +%FT%T%z)
 KS_BIN?=ks
 
+APIMACHINERY_VER := $(shell dep status | grep k8s.io/apimachinery | awk '{print $$3}')
+
 GO = go
 EXTRA_GO_FLAGS =
-GO_FLAGS = -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)" $(EXTRA_GO_FLAGS)
+GO_FLAGS = -ldflags="-X main.version=$(VERSION) -X main.apimachineryVersion=$(APIMACHINERY_VER) $(GO_LDFLAGS)" $(EXTRA_GO_FLAGS)
 GOFMT = gofmt
 # GINKGO = "go test" also works if you want to avoid ginkgo tool
 GINKGO = ginkgo

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,14 +30,22 @@ func init() {
 // Version is overridden by main
 var Version = "(dev build)"
 
+var APImachineryVersion = ""
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information for this ksonnet binary",
 	Run: func(cmd *cobra.Command, args []string) {
 		out := cmd.OutOrStdout()
+
+		clientGoVersion := fmt.Sprintf("%s.%s", version.Get().Major, version.Get().Minor)
+		if APImachineryVersion != "" {
+			clientGoVersion += fmt.Sprintf("-%s", APImachineryVersion)
+		}
+
 		fmt.Fprintln(out, "ksonnet version:", Version)
 		fmt.Fprintln(out, "jsonnet version:", jsonnet.Version())
-		fmt.Fprintln(out, "client-go version:", version.Get())
+		fmt.Fprintln(out, "client-go version:", clientGoVersion)
 	},
 	Long: `
 The ` + "`version`" + ` command prints out version info about the current ksonnet CLI,

--- a/main.go
+++ b/main.go
@@ -26,9 +26,11 @@ import (
 
 // Version is overridden using `-X main.version` during release builds
 var version = "(dev build)"
+var apimachineryVersion = ""
 
 func main() {
 	cmd.Version = version
+	cmd.APImachineryVersion = apimachineryVersion
 
 	if err := cmd.RootCmd.Execute(); err != nil {
 		// PersistentPreRunE may not have been run for early


### PR DESCRIPTION
Using `Version()` as a string leaves a preprocessed version tag in the
ksonnet version. Construct a new version using the `Major` and `Minor`
fields.

Re: #250

Signed-off-by: bryanl <bryanliles@gmail.com>