### PR TITLE
[docs] Clarify prototypes + add troubleshooting issue

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -87,7 +87,9 @@ All of the component files in an *app* can be deployed to a specified *environme
 
 ### Prototype
 
-Prototypes are often used as the basis for components; they are the reason that `ks generate` allows you to quickly move from a blank app to multiple complete manifests.
+Prototypes are *examples* that you can use as the basis for your components. By `ks generate`-ing components from prototypes, you can quickly move from a blank app to multiple complete manifests.
+
+*Although you can use these components right away, they are really intended as a starting point.* If a prototype-generated component does not fully address your needs, you can directly modify its Jsonnet afterwards (e.g. adding parameters).
 
 By itself, a prototype is a pre-written but incomplete manifest:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,10 @@
 # Troubleshooting
 
+## ERROR user: Current not implemented on linux/amd64
+If you encounter this error when running the ksonnet Linux binary, you can temporarily work around it by setting the `USER` environment variable (e.g. `export USER=your-username`).
+
+This error results from cross-compilation (Linux on Mac). To avoid this, future binaries will be built on the appropriate target machines.
+
 ## Github rate limiting errors
 
 If you get an error saying something to the effect of `403 API rate limit of 60 still exceeded` you can work around that by getting a Github personal access token and setting it up so that `ks` can use it.  Github has higher rate limits for authenticated users than unauthenticated users.


### PR DESCRIPTION
Minor doc changes to do the following:
* Clarify that prototypes are more like *examples*, rather than like Helm's plug-and-play charts
* Instructions to cover https://github.com/ksonnet/ksonnet/issues/298#issuecomment-360531855 until new binaries are released for 0.9.0.

@bryanl @jessicayuen PTAL thanks!