### PR TITLE
Add warning for running deprecated ks app against ks >= 0.9.0

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ksonnet/ksonnet/client"
+	"github.com/ksonnet/ksonnet/metadata"
 	"github.com/ksonnet/ksonnet/pkg/kubecfg"
 )
 
@@ -121,6 +122,21 @@ var applyCmd = &cobra.Command{
 		})
 		objs, err := te.Expand()
 		if err != nil {
+			return err
+		}
+
+		// TODO remove after 1.0.0
+		// We are ensuring here that users aren't running a deprecated ksonnet
+		// app structure against a newer version of ks.
+		appDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		manager, err := metadata.Find(appDir)
+		if err != nil {
+			return err
+		}
+		if err := manager.ErrorOnSpecFile(); err != nil {
 			return err
 		}
 

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -63,6 +63,8 @@ type Manager interface {
 	GetEnvironments() (app.EnvironmentSpecs, error)
 	GetEnvironment(name string) (*app.EnvironmentSpec, error)
 	SetEnvironment(name, desiredName string) error
+	// ErrorOnSpecFile is a temporary API to inform < 0.9.0 ks users of environment directory changes.
+	ErrorOnSpecFile() error
 
 	// Spec API.
 	AppSpec() (*app.Spec, error)


### PR DESCRIPTION
This is a temporary piece of code that should be removed after 1.0.0.

This warning exists to tell users that are using ks < 0.9.0 with the
dated environments model (contains the 'spec.json' file), to migrate to
the newer 'app.yaml' model.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>