### PR TITLE
Fix bug with invalid base.libsonnet import path

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -295,7 +295,7 @@ func expandEnvObjs(fs afero.Fs, cmd *cobra.Command, env string, manager metadata
 		return nil, err
 	}
 
-	_, vendorPath := manager.LibPaths()
+	envPath, vendorPath := manager.LibPaths()
 	libPath, mainPath, paramsPath, err := manager.EnvPaths(env)
 	if err != nil {
 		return nil, err
@@ -315,7 +315,7 @@ func expandEnvObjs(fs afero.Fs, cmd *cobra.Command, env string, manager metadata
 		return nil, err
 	}
 
-	expander.FlagJpath = append([]string{string(vendorPath), string(libPath)}, expander.FlagJpath...)
+	expander.FlagJpath = append([]string{string(vendorPath), string(libPath), string(envPath)}, expander.FlagJpath...)
 	expander.ExtCodes = append([]string{baseObj, params, envSpec}, expander.ExtCodes...)
 
 	envFiles := []string{string(mainPath)}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -268,13 +268,13 @@ func (te *cmdObjExpander) Expand() ([]*unstructured.Unstructured, error) {
 		return nil, errors.Wrap(err, "find metadata")
 	}
 
-	_, vendorPath := manager.LibPaths()
+	envPath, vendorPath := manager.LibPaths()
 	libPath, mainPath, _, err := manager.EnvPaths(te.config.env)
 	if err != nil {
 		return nil, err
 	}
 
-	expander.FlagJpath = append([]string{string(vendorPath), string(libPath)}, expander.FlagJpath...)
+	expander.FlagJpath = append([]string{string(vendorPath), string(libPath), string(envPath)}, expander.FlagJpath...)
 
 	namespacedComponentPaths, err := component.MakePathsByNamespace(te.config.fs, manager, te.config.cwd, te.config.env)
 	if err != nil {

--- a/integration/fixtures/sampleapp/environments/default/main.jsonnet
+++ b/integration/fixtures/sampleapp/environments/default/main.jsonnet
@@ -1,4 +1,4 @@
-local base = import "../base.libsonnet";
+local base = import "base.libsonnet";
 local k = import "k.libsonnet";
 
 base + {

--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -464,12 +464,8 @@ func (m *manager) cleanEmptyParentDirs(name string) error {
 }
 
 func (m *manager) generateOverrideData() []byte {
-	const (
-		relBaseLibsonnetPath = "../" + baseLibsonnetFile
-	)
-
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("local base = import \"%s\";\n", relBaseLibsonnetPath))
+	buf.WriteString(fmt.Sprintf("local base = import \"%s\";\n", baseLibsonnetFile))
 	buf.WriteString(fmt.Sprintf("local k = import \"%s\";\n\n", lib.ExtensionsLibFilename))
 	buf.WriteString("base + {\n")
 	buf.WriteString("  // Insert user-specified overrides here. For example if a component is named \"nginx-deployment\", you might have something like:\n")

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -249,7 +249,7 @@ func TestSetEnvironment(t *testing.T) {
 func TestGenerateOverrideData(t *testing.T) {
 	m := mockEnvironments(t, "test-gen-override-data")
 
-	expected := `local base = import "../base.libsonnet";
+	expected := `local base = import "base.libsonnet";
 local k = import "k.libsonnet";
 
 base + {

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -37,7 +37,7 @@ var defaultFilePermissions = os.FileMode(0644)
 // libraries; and other non-core-application tasks.
 type Manager interface {
 	Root() string
-	LibPaths() (libPath, vendorPath string)
+	LibPaths() (envPath, vendorPath string)
 	EnvPaths(env string) (libPath, mainPath, paramsPath string, err error)
 
 	// Components API.

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -181,8 +181,8 @@ func (m *manager) Root() string {
 	return m.rootPath
 }
 
-func (m *manager) LibPaths() (libPath, vendorPath string) {
-	return m.libPath, m.vendorPath
+func (m *manager) LibPaths() (envPath, vendorPath string) {
+	return m.environmentsPath, m.vendorPath
 }
 
 func (m *manager) createUserDirTree() error {

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -179,12 +179,12 @@ func TestFindSuccess(t *testing.T) {
 func TestLibPaths(t *testing.T) {
 	appName := "test-lib-paths"
 	expectedVendorPath := path.Join(appName, vendorDir)
-	expectedLibPath := path.Join(appName, libDir)
+	expectedEnvPath := path.Join(appName, environmentsDir)
 	m := mockEnvironments(t, appName)
 
-	libPath, vendorPath := m.LibPaths()
-	if libPath != expectedLibPath {
-		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
+	envPath, vendorPath := m.LibPaths()
+	if envPath != expectedEnvPath {
+		t.Fatalf("Expected env path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvPath, envPath)
 	}
 	if vendorPath != expectedVendorPath {
 		t.Fatalf("Expected vendor lib path to be:\n  '%s'\n, got:\n  '%s'", expectedVendorPath, vendorPath)


### PR DESCRIPTION
Fixes #321 

There exists a bug in the reference path of base.libsonnet for nested
environment directories. We are referencing a hardcoded import
"../base.libsonnet". The works for top level environment directories but
obviously does not work for nested directories.

This commit will add the environments directory as a global lib path.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>