### PR TITLE
Set param boolean types as strings

### DIFF
--- a/pkg/kubecfg/param.go
+++ b/pkg/kubecfg/param.go
@@ -94,10 +94,6 @@ func (c *ParamSetCmd) Run() error {
 // sanitizeParamValue does a best effort to identify value types. It will put
 // quotes around values which it categorizes as strings.
 func sanitizeParamValue(value string) string {
-	// boolean
-	if value == "true" || value == "false" {
-		return value
-	}
 	// numeric
 	if _, err := strconv.ParseFloat(value, 64); err == nil {
 		return value

--- a/pkg/kubecfg/param_test.go
+++ b/pkg/kubecfg/param_test.go
@@ -82,3 +82,35 @@ func TestDiffParams(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeParamValue(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		// numbers
+		{
+			value:    "64.5",
+			expected: "64.5",
+		},
+		{
+			value:    "64",
+			expected: "64",
+		},
+		// boolean
+		{
+			value:    "false",
+			expected: `"false"`,
+		},
+		// string
+		{
+			value:    "my string",
+			expected: `"my string"`,
+		},
+	}
+
+	for _, te := range tests {
+		got := sanitizeParamValue(te.value)
+		require.Equal(t, got, te.expected, "Unexpected sanitized param value")
+	}
+}


### PR DESCRIPTION
Fixes #311 

There currently exists a discrepency between the param types expected
from:
1. The parts library and in generate / prototype use
2. ks param set

ks param set will set boolean types as jsonnet boolean types, however,
prototypes will set boolean types as strings (i.e. in quotes). This
change will make it such that ks param sets boolean types as strings.
The reason we're not setting booleans in both model is because that will
require a better dependency story around ksonnet/parts first.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>