### PR TITLE
Resolve api spec based on swagger version

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -140,6 +140,9 @@ var envAddCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if specFlag == "" {
+			specFlag = envClientConfig.GetAPISpec(server)
+		}
 
 		c, err := kubecfg.NewEnvAddCmd(name, server, namespace, specFlag, manager)
 		if err != nil {

--- a/docs/cli-reference/ks_init.md
+++ b/docs/cli-reference/ks_init.md
@@ -81,7 +81,7 @@ ks init app-name --dir=custom-location
 ### Options
 
 ```
-      --api-spec string                Manually specified Kubernetes API version. The corresponding OpenAPI spec is used to generate ksonnet's Kubernetes libraries (default "version:v1.7.0")
+      --api-spec string                Manually specified Kubernetes API version. The corresponding OpenAPI spec is used to generate ksonnet's Kubernetes libraries
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --certificate-authority string   Path to a cert file for the certificate authority


### PR DESCRIPTION
Currently the Kubernetes API version used is defaulted to 1.7.0 if the
--api-spec flag is not populated. This change will attempt to retrieve
the swagger.json version from the server instead.

Note: This is currently a very trivial attempt at retrieving it from the
server. Efforts will be made later to support TLS / Certificates.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>