### PR TITLE
Fix the execution paths for the 0.8 > 0.9 migration warning

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -603,6 +603,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f44fb422720ed1d7e1a654a9c4b6f6d9baa90492bb28c459bf30552527255e83"
+  inputs-digest = "8b786abd404b80a5933fdf9b29cae67837bf6630041f144bffd7092fdb0e331c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ksonnet/ksonnet/client"
-	"github.com/ksonnet/ksonnet/metadata"
 	"github.com/ksonnet/ksonnet/pkg/kubecfg"
 )
 
@@ -122,21 +121,6 @@ var applyCmd = &cobra.Command{
 		})
 		objs, err := te.Expand()
 		if err != nil {
-			return err
-		}
-
-		// TODO remove after 1.0.0
-		// We are ensuring here that users aren't running a deprecated ksonnet
-		// app structure against a newer version of ks.
-		appDir, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		manager, err := metadata.Find(appDir)
-		if err != nil {
-			return err
-		}
-		if err := manager.ErrorOnSpecFile(); err != nil {
 			return err
 		}
 

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -63,8 +63,6 @@ type Manager interface {
 	GetEnvironments() (app.EnvironmentSpecs, error)
 	GetEnvironment(name string) (*app.EnvironmentSpec, error)
 	SetEnvironment(name, desiredName string) error
-	// ErrorOnSpecFile is a temporary API to inform < 0.9.0 ks users of environment directory changes.
-	ErrorOnSpecFile() error
 
 	// Spec API.
 	AppSpec() (*app.Spec, error)

--- a/testdata/testapp/environments/default/spec.json
+++ b/testdata/testapp/environments/default/spec.json
@@ -1,4 +1,0 @@
-{
-  "server": "example.com",
-  "namespace": "example-ns"
-}


### PR DESCRIPTION
Currently the warning is only displayed on 'apply'. Other commands
should also show this warning. Logic should also be handled internally
instead of being exposed at the interface level.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>