### PR TITLE
Parse server version from GitVersion

### DIFF
--- a/utils/meta_test.go
+++ b/utils/meta_test.go
@@ -18,6 +18,20 @@ func TestParseVersion(t *testing.T) {
 		error    bool
 	}{
 		{
+			input:    version.Info{GitVersion: "v1.7.0"},
+			expected: ServerVersion{Major: 1, Minor: 7},
+		},
+		{
+			input:    version.Info{GitVersion: "v1.7.11-gke.1"},
+			expected: ServerVersion{Major: 1, Minor: 7},
+		},
+		// Bad GitVersion case
+		{
+			input:    version.Info{Major: "1", Minor: "6", GitVersion: "invalid"},
+			expected: ServerVersion{Major: 1, Minor: 6},
+		},
+		// GitVersion does not exist cases
+		{
 			input:    version.Info{Major: "1", Minor: "6"},
 			expected: ServerVersion{Major: 1, Minor: 6},
 		},


### PR DESCRIPTION
Fixes #342

We currently attempt to parse the server version from the Major / Minor
version provided by client-go's ServerVersion object. It is not always
the case that these fields are populated; and is more accurate to use
the GitVersion.

Signed-off-by: Jessica Yuen <im.jessicayuen@gmail.com>