### PR TITLE
Add HOME to plugin env

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,7 @@ func runPlugin(p plugin.Plugin, args []string) error {
 	env := []string{
 		fmt.Sprintf("KS_PLUGIN_DIR=%s", p.RootDir),
 		fmt.Sprintf("KS_PLUGIN_NAME=%s", p.Config.Name),
+		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 	}
 
 	root, err := appRoot()


### PR DESCRIPTION
ksonnet plugins scrub the environment available to a plugin. Add `HOME`,
so client-go can find the files it is looking for.

Signed-off-by: bryanl <bryanliles@gmail.com>