### PR TITLE
Allow `ks` command to work anywhere in app

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,18 +116,14 @@ application configuration to remote clusters.
 			return err
 		}
 
-		appConfig := filepath.Join(wd, "app.yaml")
-		exists, err := afero.Exists(appFs, appConfig)
-		if err != nil {
-			return err
+		var isInit bool
+		if len(args) == 2 && args[0] == "init" {
+			isInit = true
 		}
 
-		if exists {
-			log.Debugf("loading configuration from %s", appConfig)
-			ka, err = app.Load(appFs, wd)
-			if err != nil {
-				return err
-			}
+		ka, err = app.Load(appFs, wd)
+		if err != nil && isInit {
+			return err
 		}
 
 		return nil

--- a/metadata/app/app_test.go
+++ b/metadata/app/app_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_findRoot(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	stageFile(t, fs, "app010_app.yaml", "/app/app.yaml")
+
+	dirs := []string{
+		"/app/components",
+		"/invalid",
+	}
+
+	for _, dir := range dirs {
+		err := fs.MkdirAll(dir, DefaultFilePermissions)
+		require.NoError(t, err)
+	}
+
+	cases := []struct {
+		name     string
+		expected string
+		isErr    bool
+	}{
+		{
+			name:     "/app",
+			expected: "/app",
+		},
+		{
+			name:     "/app/components",
+			expected: "/app",
+		},
+		{
+			name:  "/invalid",
+			isErr: true,
+		},
+		{
+			name:  "/missing",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := findRoot(fs, tc.name)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, root)
+		})
+	}
+
+}

--- a/metadata/app/schema.go
+++ b/metadata/app/schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -66,9 +67,13 @@ type Spec struct {
 	License      string           `json:"license,omitempty"`
 }
 
-// Read will return the specification for a ksonnet application.
-func Read(fs afero.Fs, appRoot string) (*Spec, error) {
-	bytes, err := afero.ReadFile(fs, specPath(appRoot))
+// Read will return the specification for a ksonnet application. It will navigate up directories
+// to search for `app.yaml` and return error if it hits the root directory.
+func Read(fs afero.Fs, root string) (*Spec, error) {
+	config := filepath.Join(root, appYamlName)
+	log.Debugf("loading configuration from %s", config)
+
+	bytes, err := afero.ReadFile(fs, config)
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +101,8 @@ func Read(fs afero.Fs, appRoot string) (*Spec, error) {
 
 	return schema, nil
 }
+
+
 
 // Write writes the provided spec to file system.
 func Write(fs afero.Fs, appRoot string, spec *Spec) error {


### PR DESCRIPTION
Allow ks command to work in any subdirectory of a ksonnet app. If
`app.yaml` is not found in the current directory, look for it in parent
directories.

Signed-off-by: bryanl <bryanliles@gmail.com>