### PR TITLE
handle jsonnet ast.ApplyBrace in env files

### DIFF
--- a/metadata/params/params.go
+++ b/metadata/params/params.go
@@ -63,6 +63,8 @@ func findComponentsObj(node ast.Node) (*ast.Object, error) {
 			}
 		}
 		return nil, fmt.Errorf("Invalid params schema -- there must be a top-level object '%s'", componentsID)
+	case *ast.ApplyBrace:
+		return findComponentsObj(n.Right)
 	}
 	return nil, fmt.Errorf("Invalid params schema -- did not expect node type: %T", node)
 }


### PR DESCRIPTION
Adds support for `ast.ApplyBrace` when setting parameters.

Fixes #381 


Signed-off-by: bryanl <bryanliles@gmail.com>