### PR TITLE
Print more stack frames on infinite loops

### DIFF
--- a/component/jsonnet.go
+++ b/component/jsonnet.go
@@ -145,6 +145,7 @@ func (j *Jsonnet) Objects(paramsStr, envName string) ([]*unstructured.Unstructur
 	}
 
 	vm := jsonnet.MakeVM()
+	vm.ErrorFormatter.SetMaxStackTraceSize(40)
 	vm.Importer(importer)
 	log.Debugf("%s convert to jsonnet: setting %q to %q", j.Name(true), "__ksonnet/params", paramsStr)
 	vm.ExtCode("__ksonnet/params", paramsStr)


### PR DESCRIPTION
When max stack traces exceeded, often there is no enough user-written code seen to identify source of the loop. this change makes it it print more stack frames