### PR TITLE
Print location of kubeconfig

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -237,7 +237,7 @@ func (c *Config) ResolveContext(context string) (server, namespace string, err e
 		return "", "", errors.Errorf("context '%s' does not exist in the kubeconfig file", context)
 	}
 
-	log.Infof("Using context '%s' from the kubeconfig file specified at the environment variable $KUBECONFIG", context)
+	log.Infof("Using context %q from kubeconfig file %q", context, ctx.LocationOfOrigin)
 	cluster, exists := rawConfig.Clusters[ctx.Cluster]
 	if !exists {
 		return "", "", errors.Errorf("No cluster with name '%s' exists", ctx.Cluster)


### PR DESCRIPTION
When using a kubeconfig file from an environment variable, supplied by a
command line argument, or the default location, print the location of
the file.

Fixes #287

Signed-off-by: bryanl <bryanliles@gmail.com>