### PR TITLE
Merge in new YAML params

### DIFF
--- a/component/params.go
+++ b/component/params.go
@@ -26,7 +26,7 @@ func applyGlobals(params string) (string, error) {
 	vm := jsonnet.NewVM()
 
 	vm.ExtCode("params", params)
-	return vm.EvaluateSnippet("snippet", snippetMapGlobal)
+	return vm.EvaluateSnippet("applyGlobals", snippetMapGlobal)
 }
 
 var snippetMapGlobal = `
@@ -48,7 +48,7 @@ func patchJSON(jsonObject, patch, patchName string) (string, error) {
 	vm.TLACode("patch", patch)
 	vm.TLAVar("patchName", patchName)
 
-	return vm.EvaluateSnippet("snippet", snippetMergeComponentPatch)
+	return vm.EvaluateSnippet("patchJSON", snippetMergeComponentPatch)
 }
 
 var snippetMergeComponentPatch = `

--- a/component/testdata/params-annotations.libsonnet
+++ b/component/testdata/params-annotations.libsonnet
@@ -1,0 +1,17 @@
+{
+  global: {
+    // User-defined global parameters; accessible to all component and environments, Ex:
+    // replicas: 4,
+  },
+  components: {
+    // Component-level parameters, defined initially from 'ks prototype use ...'
+    // Each object below should correspond to a component in the components/ directory
+    "deployment-0": {
+      metadata: {
+        annotations: {
+          size: "large",
+        },
+      },
+    },
+  },
+}

--- a/pkg/schema/value_extractor_test.go
+++ b/pkg/schema/value_extractor_test.go
@@ -175,7 +175,8 @@ var (
 					Value:  "nginx-deployment"},
 				"apps.v1beta2.deployment.mixin.spec.replicas": Values{
 					Lookup: []string{"spec", "replicas"},
-					Setter: "apps.v1beta2.deployment.mixin.spec.withReplicas", Value: 3}},
+					Setter: "apps.v1beta2.deployment.mixin.spec.withReplicas",
+					Value:  3}},
 		},
 	}
 )


### PR DESCRIPTION
When a component is YAML and has params that creates new keys, merge
those new params in rather than ignoring them.

Fixes #426

Signed-off-by: bryanl <bryanliles@gmail.com>