### PR TITLE
Set maps in arrays from cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -281,7 +281,7 @@
     "ksonnet-gen/nodemaker",
     "ksonnet-gen/printer"
   ]
-  revision = "758513730c71cca2aea690ccc134e5191436ee52"
+  revision = "53ecc7e4b3a753ec7756a331be2426f615700771"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -695,6 +695,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22edca076ec91efdc60df12ca4d85edd93a4b30a83b064f425af456b6c80debb"
+  inputs-digest = "317447e871fb874f3ca9cc64c892a4358f280472db724bfd47a23611a21fc00a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,7 +54,7 @@
 
 [[constraint]]
   name = "github.com/ksonnet/ksonnet-lib"
-  revision = "758513730c71cca2aea690ccc134e5191436ee52"
+  revision = "53ecc7e4b3a753ec7756a331be2426f615700771"
 
 [[constraint]]
   name = "github.com/mattn/go-isatty"

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/nodemaker/nodemaker.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/nodemaker/nodemaker.go
@@ -127,6 +127,8 @@ func convertValueToNoder(val interface{}) (Noder, error) {
 		return NewInt(t), nil
 	case bool:
 		return NewBoolean(t), nil
+	case map[string]interface{}:
+		return ValueToNoder(t)
 	default:
 		return nil, errors.Errorf("unsupported type %T", t)
 	}


### PR DESCRIPTION
Running:

```
ks param set my-service envs '[{"name": "value1"},{"name": "value2"}]'
```

Produces the following in params.libsonnet

```javascript
{
  components: {
    "my-service": {
      envs: [{
        name: "value1",
      },{
        name: "value2",
      }],
    },
  },
}
```

Fixes #448

Signed-off-by: bryanl <bryanliles@gmail.com>