### PR TITLE
Allow setting nested global env vars from cli

### DIFF
--- a/metadata/params/params.go
+++ b/metadata/params/params.go
@@ -174,15 +174,18 @@ func writeParams(indent int, params Params) string {
 	var buffer bytes.Buffer
 	buffer.WriteString("\n")
 	for i, key := range keys {
-		param := params[key]
-		key := str.QuoteNonASCII(key)
+		param, err := params.StringValue(key)
+		if err != nil {
+			param = ""
+		}
+		key = str.QuoteNonASCII(key)
 
 		if strings.HasPrefix(param, "|||\n") {
 			// every line in a block string needs to be indented
 			lines := strings.Split(param, "\n")
 			buffer.WriteString(fmt.Sprintf("%s%s: %s\n", indentBuffer.String(), key, lines[0]))
-			for i := 1; i < len(lines)-1; i++ {
-				buffer.WriteString(fmt.Sprintf("  %s%s\n", indentBuffer.String(), lines[i]))
+			for j := 1; j < len(lines)-1; j++ {
+				buffer.WriteString(fmt.Sprintf("  %s%s\n", indentBuffer.String(), lines[j]))
 			}
 			buffer.WriteString(fmt.Sprintf("%s|||,", indentBuffer.String()))
 		} else {

--- a/metadata/params/params_test.go
+++ b/metadata/params/params_test.go
@@ -25,6 +25,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFromPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    interface{}
+		expected Params
+	}{
+		{
+			name:  "key",
+			value: "value",
+			expected: Params{
+				"key": "value",
+			},
+		},
+		{
+			name:  "metadata.name",
+			value: "value",
+			expected: Params{
+				"metadata": Params{
+					"name": "value",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := FromPath(tc.name, tc.value)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, p)
+		})
+	}
+}
+
 func TestAppendComponentParams(t *testing.T) {
 	tests := []struct {
 		componentName string

--- a/pkg/actions/param_set.go
+++ b/pkg/actions/param_set.go
@@ -143,8 +143,9 @@ func setEnv(ksApp app.App, envName, name, pName, value string) error {
 }
 
 func setGlobalEnv(ksApp app.App, envName, pName, value string) error {
-	p := mp.Params{
-		pName: value,
+	p, err := mp.FromPath(pName, value)
+	if err != nil {
+		return err
 	}
 
 	return env.SetGlobalParams(ksApp, envName, p)

--- a/pkg/actions/prototype_use.go
+++ b/pkg/actions/prototype_use.go
@@ -129,19 +129,24 @@ func (pl *PrototypeUse) Run() error {
 		flags.Set("name", componentName)
 	}
 
-	params, err := getParameters(p, flags)
+	rawParams, err := getParameters(p, flags)
 	if err != nil {
 		return err
 	}
 
 	_, prototypeName := component.ExtractModuleComponent(pl.app, componentName)
 
-	text, err := expandPrototype(p, templateType, params, prototypeName)
+	text, err := expandPrototype(p, templateType, rawParams, prototypeName)
 	if err != nil {
 		return err
 	}
 
-	_, err = pl.createComponentFn(pl.app, componentName, text, params, templateType)
+	ps := param.Params{}
+	for k, v := range rawParams {
+		ps[k] = v
+	}
+
+	_, err = pl.createComponentFn(pl.app, componentName, text, ps, templateType)
 	if err != nil {
 		return errors.Wrap(err, "create component")
 	}

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ksonnet/ksonnet/metadata/params"
 	"github.com/ksonnet/ksonnet/pkg/app/mocks"
 	"github.com/ksonnet/ksonnet/pkg/prototype"
 
@@ -32,7 +33,7 @@ func Test_Create(t *testing.T) {
 	cases := []struct {
 		name          string
 		isErr         bool
-		params        map[string]string
+		params        params.Params
 		templateType  prototype.TemplateType
 		componentDir  string
 		ns            string
@@ -40,7 +41,7 @@ func Test_Create(t *testing.T) {
 	}{
 		{
 			name: "jsonnet component",
-			params: map[string]string{
+			params: params.Params{
 				"name": "name",
 			},
 			templateType:  prototype.Jsonnet,
@@ -49,7 +50,7 @@ func Test_Create(t *testing.T) {
 		},
 		{
 			name: "yaml component",
-			params: map[string]string{
+			params: params.Params{
 				"name": "name",
 			},
 			templateType:  prototype.YAML,
@@ -58,7 +59,7 @@ func Test_Create(t *testing.T) {
 		},
 		{
 			name: "json component",
-			params: map[string]string{
+			params: params.Params{
 				"name": "name",
 			},
 			templateType:  prototype.JSON,
@@ -67,7 +68,7 @@ func Test_Create(t *testing.T) {
 		},
 		{
 			name: "invalid component",
-			params: map[string]string{
+			params: params.Params{
 				"name": "name",
 			},
 			templateType: prototype.TemplateType("unknown"),
@@ -75,7 +76,7 @@ func Test_Create(t *testing.T) {
 		},
 		{
 			name:          "nested/component",
-			params:        map[string]string{"name": "name"},
+			params:        params.Params{"name": "name"},
 			templateType:  prototype.Jsonnet,
 			componentName: "nested/component",
 			componentDir:  "/components/nested",

--- a/pkg/params/env_globals_set.go
+++ b/pkg/params/env_globals_set.go
@@ -66,12 +66,28 @@ func (egs *EnvGlobalsSet) Set(snippet string, p params.Params) (string, error) {
 
 func (egs *EnvGlobalsSet) setParams(obj *astext.Object, p params.Params) error {
 	for key := range p {
-		decoded, err := jsonnet.DecodeValue(p[key])
-		if err != nil {
-			return err
+
+		v := p[key]
+		if p1, ok := v.(params.Params); ok {
+			// convert params to map[string]interface{} so nodemaker can deal with it.
+			m := make(map[string]interface{})
+			for k1, v1 := range p1 {
+				if s, ok := v1.(string); ok {
+					decoded, err := jsonnet.DecodeValue(s)
+					if err != nil {
+						return err
+					}
+
+					m[k1] = decoded
+				} else {
+					m[k1] = v1
+				}
+
+			}
+			v = m
 		}
 
-		value, err := nm.ValueToNoder(decoded)
+		value, err := nm.ValueToNoder(v)
 		if err != nil {
 			return err
 		}

--- a/pkg/params/env_param_set.go
+++ b/pkg/params/env_param_set.go
@@ -101,7 +101,12 @@ func (epa *EnvParamSet) setParams(obj *astext.Object, componentName string, p pa
 	}
 
 	for key := range p {
-		decoded, err := jsonnet.DecodeValue(p[key])
+		s, err := p.StringValue(key)
+		if err != nil {
+			return err
+		}
+
+		decoded, err := jsonnet.DecodeValue(s)
 		if err != nil {
 			return err
 		}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -203,6 +203,7 @@ func (p *Pipeline) moduleObjects(module component.Module, filter []string) ([]*u
 			if err != nil {
 				return nil, errors.Wrap(err, "patch Jsonnet component")
 			}
+
 		case "yaml":
 			patched, err = params.PatchJSON(string(data), envParamData, k)
 			if err != nil {


### PR DESCRIPTION
Allows command `ks param set metadata.labels '{"project":"zeus"}'  --env default` to work

Signed-off-by: bryanl <bryanliles@gmail.com>