### PR TITLE
Support double quoted params in prototypes

### DIFF
--- a/pkg/prototype/snippet/jsonnet/snippet.go
+++ b/pkg/prototype/snippet/jsonnet/snippet.go
@@ -307,8 +307,8 @@ func visitLocalBind(node ast.LocalBind, imports *[]ast.Import) error {
 }
 
 var (
-	reParam = regexp.MustCompile(`(?s)import\s+(\/\/.*?)?'param:\/\/(\w+)'`)
-	reEnv   = regexp.MustCompile(`(?s)import\s+(\/\/.*?)?'env:\/\/(\w+)'`)
+	reParam = regexp.MustCompile(`(?s)import\s+(\/\/.*?)?['"]param:\/\/(\w+)['"]`)
+	reEnv   = regexp.MustCompile(`(?s)import\s+(\/\/.*?)?['"]env:\/\/(\w+)['"]`)
 )
 
 // replace converts all parameters in the passed Jsonnet of form

--- a/pkg/prototype/specification_test.go
+++ b/pkg/prototype/specification_test.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package prototype
 
 import (


### PR DESCRIPTION
The real issue is tracked in #478, but this fix will solve the immediate
problem.

Fixes #475

Signed-off-by: bryanl <bryanliles@gmail.com>