### PR TITLE
Add environment path to jpath for relative imports

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -99,6 +99,11 @@ func Evaluate(a app.App, envName, components, paramsStr string) (string, error) 
 		return "", err
 	}
 
+	appEnv, err := a.Environment(envName)
+	if err != nil {
+		return "", err
+	}
+
 	snippet, err := MainFile(a, envName)
 	if err != nil {
 		return "", err
@@ -108,6 +113,7 @@ func Evaluate(a app.App, envName, components, paramsStr string) (string, error) 
 	vm.AddJPath(componentJPaths...)
 	vm.AddJPath(
 		filepath.Join(a.Root(), envRootName),
+		filepath.Join(a.Root(), envRootName, appEnv.Path),
 		filepath.Join(a.Root(), "vendor"),
 		libPath,
 	)


### PR DESCRIPTION
enviroment `main.jsonnet` files updated the path of the import of
`base.libsonnet` to remove the relative bits because you can't assume
that the environment root is directly off the root. This breaks older
applications. The fix is to add the environment path to the jpath.

Fixes #493

Signed-off-by: bryanl <bryanliles@gmail.com>