### PR TITLE
decode string with leading 0 as string

### DIFF
--- a/pkg/util/jsonnet/object.go
+++ b/pkg/util/jsonnet/object.go
@@ -248,8 +248,8 @@ func arrayValues(array *ast.Array) ([]interface{}, error) {
 }
 
 var (
-	reFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+$`)
-	reInt   = regexp.MustCompile(`^([+-]?[1-9]\d*|0)$`)
+	reFloat = regexp.MustCompile(`^[-+]?(0|[1-9]\d+)(\.[0-9]+)*$`)
+	reInt   = regexp.MustCompile(`^([+-]?[1-9]\d*|0{1})$`)
 	reArray = regexp.MustCompile(`^\[`)
 	reMap   = regexp.MustCompile(`^\{`)
 )

--- a/pkg/util/jsonnet/object_test.go
+++ b/pkg/util/jsonnet/object_test.go
@@ -242,6 +242,11 @@ func TestDecodeValue(t *testing.T) {
 			expected: 0,
 		},
 		{
+			name:     "00",
+			val:      "00",
+			expected: "00",
+		},
+		{
 			name:     "bool true",
 			val:      "True",
 			expected: true,


### PR DESCRIPTION
When setting parameters, if the value starts with a leading 0 and is
not a float, consider it to be a string.

e.g.:

00: string
0.1: float
0: int

#492

Signed-off-by: bryanl <bryanliles@gmail.com>