### PR TITLE
Allow forcing a parameter value to string

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -29,6 +29,8 @@ const (
 	OptionApp = "app"
 	// OptionArguments is arguments option. Used for passing arguments to prototypes.
 	OptionArguments = "arguments"
+	// OptionAsString is asString. Used for setting values as strings.
+	OptionAsString = "as-string"
 	// OptionClientConfig is clientConfig option.
 	OptionClientConfig = "client-config"
 	// OptionComponentName is a componentName option.

--- a/pkg/actions/param_set.go
+++ b/pkg/actions/param_set.go
@@ -44,6 +44,7 @@ type ParamSet struct {
 	rawValue string
 	global   bool
 	envName  string
+	asString bool
 
 	getModuleFn    getModuleFn
 	resolvePathFn  func(a app.App, path string) (component.Module, component.Component, error)
@@ -62,6 +63,7 @@ func NewParamSet(m map[string]interface{}) (*ParamSet, error) {
 		rawValue: ol.LoadString(OptionValue),
 		global:   ol.LoadOptionalBool(OptionGlobal),
 		envName:  ol.LoadOptionalString(OptionEnvName),
+		asString: ol.LoadOptionalBool(OptionAsString),
 
 		getModuleFn:    component.GetModule,
 		resolvePathFn:  component.ResolvePath,
@@ -82,9 +84,16 @@ func NewParamSet(m map[string]interface{}) (*ParamSet, error) {
 
 // Run runs the action.
 func (ps *ParamSet) Run() error {
-	value, err := jsonnet.DecodeValue(ps.rawValue)
-	if err != nil {
-		return errors.Wrap(err, "value is invalid")
+	var value interface{}
+	var err error
+
+	if ps.asString {
+		value = ps.rawValue
+	} else {
+		value, err = jsonnet.DecodeValue(ps.rawValue)
+		if err != nil {
+			return errors.Wrap(err, "value is invalid")
+		}
 	}
 
 	if ps.envName != "" {

--- a/pkg/actions/param_set_test.go
+++ b/pkg/actions/param_set_test.go
@@ -54,6 +54,35 @@ func TestParamSet(t *testing.T) {
 	})
 }
 
+func TestParamSet_asString(t *testing.T) {
+	withApp(t, func(appMock *amocks.App) {
+		componentName := "deployment"
+		path := "label"
+		value := "3"
+
+		c := &cmocks.Component{}
+		c.On("SetParam", []string{"label"}, "3").Return(nil)
+
+		in := map[string]interface{}{
+			OptionApp:      appMock,
+			OptionName:     componentName,
+			OptionPath:     path,
+			OptionValue:    value,
+			OptionAsString: true,
+		}
+
+		a, err := NewParamSet(in)
+		require.NoError(t, err)
+
+		a.resolvePathFn = func(app.App, string) (component.Module, component.Component, error) {
+			return nil, c, nil
+		}
+
+		err = a.Run()
+		require.NoError(t, err)
+	})
+}
+
 func TestParamSet_global(t *testing.T) {
 	withApp(t, func(appMock *amocks.App) {
 		module := "/"

--- a/pkg/clicmd/flags.go
+++ b/pkg/clicmd/flags.go
@@ -19,6 +19,7 @@ const (
 	// For use in the commands (e.g., diff, apply, delete) that require either an
 	// environment or the -f flag.
 	flagAPISpec               = "api-spec"
+	flagAsString              = "as-string"
 	flagComponent             = "component"
 	flagCreate                = "create"
 	flagDir                   = "dir"

--- a/pkg/clicmd/helpers_test.go
+++ b/pkg/clicmd/helpers_test.go
@@ -22,11 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runCmd(args ...string) error {
-	RootCmd.SetArgs(args)
-	return RootCmd.Execute()
-}
-
 func withCmd(id initName, override actionFn, fn func()) {
 	if override != nil {
 		ogFn := actionFns[id]
@@ -63,8 +58,9 @@ func runTestCmd(t *testing.T, cases []cmdTestCase) {
 			s := stubCmdOverride{}
 
 			withCmd(tc.action, s.override, func() {
+				RootCmd.SetArgs(tc.args)
 
-				err := runCmd(tc.args...)
+				err := RootCmd.Execute()
 				if tc.isErr {
 					require.Error(t, err)
 					return

--- a/pkg/clicmd/param_set.go
+++ b/pkg/clicmd/param_set.go
@@ -23,7 +23,8 @@ import (
 )
 
 var (
-	vParamSetEnv = "param-set-env"
+	vParamSetEnv      = "param-set-env"
+	vParamSetAsString = "param-set-as-string"
 )
 
 var paramSetCmd = &cobra.Command{
@@ -47,11 +48,12 @@ var paramSetCmd = &cobra.Command{
 		}
 
 		m := map[string]interface{}{
-			actions.OptionApp:     ka,
-			actions.OptionName:    name,
-			actions.OptionPath:    path,
-			actions.OptionValue:   value,
-			actions.OptionEnvName: viper.GetString(vParamSetEnv),
+			actions.OptionApp:      ka,
+			actions.OptionName:     name,
+			actions.OptionPath:     path,
+			actions.OptionValue:    value,
+			actions.OptionEnvName:  viper.GetString(vParamSetEnv),
+			actions.OptionAsString: viper.GetBool(vParamSetAsString),
 		}
 
 		return runAction(actionParamSet, m)
@@ -89,4 +91,7 @@ func init() {
 
 	paramSetCmd.Flags().String(flagEnv, "", "Specify environment to set parameters for")
 	viper.BindPFlag(vParamSetEnv, paramSetCmd.Flags().Lookup(flagEnv))
+
+	paramSetCmd.Flags().Bool(flagAsString, false, "Force value to be interpreted as string")
+	viper.BindPFlag(vParamSetAsString, paramSetCmd.Flags().Lookup(flagAsString))
 }

--- a/pkg/clicmd/param_set_test.go
+++ b/pkg/clicmd/param_set_test.go
@@ -28,23 +28,26 @@ func Test_paramSetCmd(t *testing.T) {
 			args:   []string{"param", "set", "component-name", "param-name", "param-value"},
 			action: actionParamSet,
 			expected: map[string]interface{}{
-				actions.OptionApp:     ka,
-				actions.OptionName:    "component-name",
-				actions.OptionPath:    "param-name",
-				actions.OptionValue:   "param-value",
-				actions.OptionEnvName: "",
+				actions.OptionApp:      ka,
+				actions.OptionName:     "component-name",
+				actions.OptionPath:     "param-name",
+				actions.OptionValue:    "param-value",
+				actions.OptionEnvName:  "",
+				actions.OptionAsString: false,
 			},
 		},
+
 		{
 			name:   "set env global",
 			args:   []string{"param", "set", "param-name", "param-value", "--env", "default"},
 			action: actionParamSet,
 			expected: map[string]interface{}{
-				actions.OptionApp:     ka,
-				actions.OptionName:    "",
-				actions.OptionPath:    "param-name",
-				actions.OptionValue:   "param-value",
-				actions.OptionEnvName: "default",
+				actions.OptionApp:      ka,
+				actions.OptionName:     "",
+				actions.OptionPath:     "param-name",
+				actions.OptionValue:    "param-value",
+				actions.OptionEnvName:  "default",
+				actions.OptionAsString: false,
 			},
 		},
 		{
@@ -52,6 +55,19 @@ func Test_paramSetCmd(t *testing.T) {
 			args:   []string{"param", "set"},
 			action: actionParamSet,
 			isErr:  true,
+		},
+		{
+			name:   "force string value",
+			args:   []string{"param", "set", "component-name", "param-name", "param-value", "--as-string", "--env", ""},
+			action: actionParamSet,
+			expected: map[string]interface{}{
+				actions.OptionApp:      ka,
+				actions.OptionName:     "component-name",
+				actions.OptionPath:     "param-name",
+				actions.OptionValue:    "param-value",
+				actions.OptionEnvName:  "",
+				actions.OptionAsString: true,
+			},
 		},
 	}
 


### PR DESCRIPTION
Adds ability to force a paramter value to string using the `--as-string`
flag.

e.g.

```
[I] mule · value-string-type-hint± ⟩ ks param set comp aDigit 1
[I] mule · value-string-type-hint± ⟩ ks param list comp
COMPONENT PARAM    VALUE
========= =====    =====
comp      aDigit   1
comp      bindings [{"name":"name","role":"role","users":["user1","user2"]}]
[I] mule · value-string-type-hint± ⟩ ks param set comp aDigit 1 --as-string
[I] mule · value-string-type-hint± ⟩ ks param list comp
COMPONENT PARAM    VALUE
========= =====    =====
comp      aDigit   "1"
comp      bindings [{"name":"name","role":"role","users":["user1","user2"]}]
```

Fixes #496
Fixes #492

Signed-off-by: bryanl <bryanliles@gmail.com>