### PR TITLE
Disable environment ksonnet-lib import by default

### DIFF
--- a/pkg/env/data.go
+++ b/pkg/env/data.go
@@ -24,7 +24,8 @@ const (
 
 // DefaultOverrideData generates the contents for an environment's `main.jsonnet`.
 var DefaultOverrideData = []byte(`local base = import "base.libsonnet";
-local k = import "k.libsonnet";
+// uncomment if you reference ksonnet-lib
+// local k = import "k.libsonnet";
 
 base + {
   // Insert user-specified overrides here. For example if a component is named \"nginx-deployment\", you might have something like:\n")


### PR DESCRIPTION
import is not needed if it isn't being used

Fixes #514

Signed-off-by: bryanl <bryanliles@gmail.com>