### PR TITLE
Add multiple levels of logging verbosity

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// VerbosityLevel is the current verbosity level.
+	VerbosityLevel = 0
+)
+
+// Init initializes ksonnet's logger.
+func Init(verbosity int, w io.Writer) {
+	logrus.SetOutput(w)
+	logrus.SetFormatter(defaultLogFmt())
+	logrus.SetLevel(logLevel(verbosity))
+	VerbosityLevel = verbosity
+
+	logrus.WithField("verbosity-level", verbosity).Debug("setting log verbosity")
+}
+
+func defaultLogFmt() logrus.Formatter {
+	return &logrus.TextFormatter{
+		DisableTimestamp:       true,
+		DisableLevelTruncation: true,
+		QuoteEmptyFields:       true,
+	}
+}
+
+func logLevel(verbosity int) logrus.Level {
+	switch verbosity {
+	case 0:
+		return logrus.InfoLevel
+	default:
+		return logrus.DebugLevel
+	}
+}

--- a/pkg/util/jsonnet/vm.go
+++ b/pkg/util/jsonnet/vm.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/ast"
+	"github.com/ksonnet/ksonnet/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -110,9 +111,12 @@ func (vm *VM) EvaluateSnippet(name, snippet string) (string, error) {
 	now := time.Now()
 
 	fields := logrus.Fields{
-		"jPaths":  strings.Join(vm.jPaths, ", "),
-		"name":    name,
-		"snippet": snippet,
+		"jPaths": strings.Join(vm.jPaths, ", "),
+		"name":   name,
+	}
+
+	if log.VerbosityLevel >= 2 {
+		fields["snippet"] = snippet
 	}
 
 	jvm := jsonnet.MakeVM()
@@ -126,26 +130,34 @@ func (vm *VM) EvaluateSnippet(name, snippet string) (string, error) {
 
 	for k, v := range vm.extCodes {
 		jvm.ExtCode(k, v)
-		key := fmt.Sprintf("extCode#%s", k)
-		fields[key] = v
+		if log.VerbosityLevel >= 2 {
+			key := fmt.Sprintf("extCode#%s", k)
+			fields[key] = v
+		}
 	}
 
 	for k, v := range vm.extVars {
 		jvm.ExtVar(k, v)
-		key := fmt.Sprintf("extVar#%s", k)
-		fields[key] = v
+		if log.VerbosityLevel >= 2 {
+			key := fmt.Sprintf("extVar#%s", k)
+			fields[key] = v
+		}
 	}
 
 	for k, v := range vm.tlaCodes {
 		jvm.TLACode(k, v)
-		key := fmt.Sprintf("tlaCode#%s", k)
-		fields[key] = v
+		if log.VerbosityLevel >= 2 {
+			key := fmt.Sprintf("tlaCode#%s", k)
+			fields[key] = v
+		}
 	}
 
 	for k, v := range vm.tlaVars {
 		jvm.TLAVar(k, v)
-		key := fmt.Sprintf("tlaVar#%s", k)
-		fields[key] = v
+		if log.VerbosityLevel >= 2 {
+			key := fmt.Sprintf("tlaVar#%s", k)
+			fields[key] = v
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
Adds multiple levels of logging verbosity. Squelches jsonnet vm output
unless `-vv` is passed to `ks`.

Signed-off-by: bryanl <bryanliles@gmail.com>