### PR TITLE
Error gracefully when running app related commands outside of app

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -123,7 +123,7 @@ const (
 var (
 	// ErrNotInApp is an error stating the user is not in a ksonnet application directory
 	// hierarchy.
-	ErrNotInApp = errors.Errorf("could not find ksonnet app")
+	ErrNotInApp = errors.Errorf("this command has to be run within a ksonnet application")
 )
 
 type missingOptionError struct {
@@ -154,7 +154,12 @@ func (e *invalidOptionError) Error() string {
 	return fmt.Sprintf("invalid type for option %s", e.name)
 }
 
+// optionLoader loads typed option from a configuration map. If an error
+// occurs in any of the load processes, the loader will return default
+// values for type.
 type optionLoader struct {
+	// err is the error state for the optionLoader. If this is not nil, all
+	// subsequent calls to load will return nil.
 	err error
 	m   map[string]interface{}
 }

--- a/pkg/actions/apply_test.go
+++ b/pkg/actions/apply_test.go
@@ -104,3 +104,9 @@ func TestApply_invalid_input(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestApply_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newApply(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/component_list_test.go
+++ b/pkg/actions/component_list_test.go
@@ -146,3 +146,9 @@ func TestComponentList_wide(t *testing.T) {
 		assertOutput(t, "component/list/wide.txt", buf.String())
 	})
 }
+
+func TestComponentList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewComponentList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/component_rm_test.go
+++ b/pkg/actions/component_rm_test.go
@@ -52,3 +52,9 @@ func TestComponentRm(t *testing.T) {
 		assert.True(t, didDelete)
 	})
 }
+
+func TestComponentRm_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewComponentRm(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/delete_test.go
+++ b/pkg/actions/delete_test.go
@@ -98,3 +98,9 @@ func TestDelete_invalid_input(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestDelete_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newDelete(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/diff_test.go
+++ b/pkg/actions/diff_test.go
@@ -95,3 +95,9 @@ func TestDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestDiff_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewDiff(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_add_test.go
+++ b/pkg/actions/env_add_test.go
@@ -62,3 +62,9 @@ func TestEnvAdd(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestEnvAdd_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvAdd(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_current_test.go
+++ b/pkg/actions/env_current_test.go
@@ -95,3 +95,9 @@ func TestEnvCurrent_invalid_input(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestEnvCurrent_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newEnvCurrent(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_describe_test.go
+++ b/pkg/actions/env_describe_test.go
@@ -51,3 +51,9 @@ func TestEnvDescribe(t *testing.T) {
 		assertOutput(t, "env/describe/output.txt", buf.String())
 	})
 }
+
+func TestEnvDescribe_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvDescribe(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_list_test.go
+++ b/pkg/actions/env_list_test.go
@@ -95,3 +95,9 @@ func TestEnvList(t *testing.T) {
 
 	})
 }
+
+func TestEnvList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_rm_test.go
+++ b/pkg/actions/env_rm_test.go
@@ -50,3 +50,9 @@ func TestEnvRm(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestEnvRm_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvRm(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_set_test.go
+++ b/pkg/actions/env_set_test.go
@@ -143,3 +143,9 @@ func TestEnvSet_name_and_namespace(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestEnvSet_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvSet(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_targets_test.go
+++ b/pkg/actions/env_targets_test.go
@@ -113,3 +113,9 @@ func TestEnvTargets_invalid_environment(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestEnvTargets_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewEnvTargets(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/env_update_test.go
+++ b/pkg/actions/env_update_test.go
@@ -51,3 +51,9 @@ func TestEnvUpdate(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestEnvUpdate_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newEnvUpdate(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/import_test.go
+++ b/pkg/actions/import_test.go
@@ -167,3 +167,9 @@ func TestImport_invalid_file(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestImport_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewImport(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/module_create.go
+++ b/pkg/actions/module_create.go
@@ -49,6 +49,10 @@ func NewModuleCreate(m map[string]interface{}) (*ModuleCreate, error) {
 		cm: component.DefaultManager,
 	}
 
+	if ol.err != nil {
+		return nil, ol.err
+	}
+
 	return mc, nil
 }
 

--- a/pkg/actions/module_create_test.go
+++ b/pkg/actions/module_create_test.go
@@ -71,3 +71,9 @@ func TestModuleCreate_already_exists(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestModuleCreate_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewModuleCreate(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/module_list_test.go
+++ b/pkg/actions/module_list_test.go
@@ -54,3 +54,9 @@ func TestModuleList(t *testing.T) {
 		assertOutput(t, "ns/list/output.txt", buf.String())
 	})
 }
+
+func TestModuleList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewModuleList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/param_delete_test.go
+++ b/pkg/actions/param_delete_test.go
@@ -131,3 +131,9 @@ func TestParamDelete_env_global(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestParamDelete_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewParamDelete(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/param_diff_test.go
+++ b/pkg/actions/param_diff_test.go
@@ -78,3 +78,9 @@ func TestParamDiff(t *testing.T) {
 		assertOutput(t, filepath.Join("param", "diff", "output.txt"), buf.String())
 	})
 }
+
+func TestParamDiff_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewParamDiff(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/param_list_test.go
+++ b/pkg/actions/param_list_test.go
@@ -137,3 +137,9 @@ func TestParamList(t *testing.T) {
 		}
 	})
 }
+
+func TestParamList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewParamList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/param_set_test.go
+++ b/pkg/actions/param_set_test.go
@@ -170,3 +170,9 @@ func TestParamSet_envGlobal(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestParamSet_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewParamSet(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/pkg_describe_test.go
+++ b/pkg/actions/pkg_describe_test.go
@@ -92,3 +92,9 @@ func TestPkgDescribe_registry(t *testing.T) {
 		assertOutput(t, "pkg/describe/output.txt", buf.String())
 	})
 }
+
+func TestPkgDescribe_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPkgDescribe(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/pkg_install_test.go
+++ b/pkg/actions/pkg_install_test.go
@@ -66,3 +66,9 @@ func TestPkgInstall(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestPkgInstall_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPkgInstall(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/pkg_list_test.go
+++ b/pkg/actions/pkg_list_test.go
@@ -64,3 +64,9 @@ func TestPkgList(t *testing.T) {
 		assertOutput(t, "pkg/list/output.txt", buf.String())
 	})
 }
+
+func TestPkgList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPkgList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/prototype_describe.go
+++ b/pkg/actions/prototype_describe.go
@@ -57,6 +57,10 @@ func NewPrototypeDescribe(m map[string]interface{}) (*PrototypeDescribe, error) 
 		appPrototypesFn: pkg.LoadPrototypes,
 	}
 
+	if ol.err != nil {
+		return nil, ol.err
+	}
+
 	return pd, nil
 }
 
@@ -103,6 +107,10 @@ func (pd *PrototypeDescribe) Run() error {
 type prototypeFn func(app.App, pkg.Descriptor) (prototype.Prototypes, error)
 
 func allPrototypes(a app.App, appPrototypes prototypeFn) (prototype.Prototypes, error) {
+	if a == nil {
+		return nil, errors.New("app is required")
+	}
+
 	libraries, err := a.Libraries()
 	if err != nil {
 		return nil, err

--- a/pkg/actions/prototype_describe_test.go
+++ b/pkg/actions/prototype_describe_test.go
@@ -47,3 +47,9 @@ func TestPrototypeDescribe(t *testing.T) {
 		assertOutput(t, "prototype/describe/output.txt", buf.String())
 	})
 }
+
+func TestPrototypeDescribe_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPrototypeDescribe(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/prototype_list_test.go
+++ b/pkg/actions/prototype_list_test.go
@@ -46,3 +46,9 @@ func TestPrototypeList(t *testing.T) {
 		assertOutput(t, "prototype/list/output.txt", buf.String())
 	})
 }
+
+func TestPrototypeList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPrototypeList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/prototype_preview_test.go
+++ b/pkg/actions/prototype_preview_test.go
@@ -54,3 +54,9 @@ func TestPrototypePreview(t *testing.T) {
 		assertOutput(t, "prototype/preview/output.txt", buf.String())
 	})
 }
+
+func TestPrototypePreview_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPrototypePreview(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/prototype_search_test.go
+++ b/pkg/actions/prototype_search_test.go
@@ -57,3 +57,9 @@ func TestPrototypeSearch(t *testing.T) {
 		assertOutput(t, "prototype/search/output.txt", buf.String())
 	})
 }
+
+func TestProtoptypeSearch_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPrototypeSearch(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/prototype_use_test.go
+++ b/pkg/actions/prototype_use_test.go
@@ -69,3 +69,9 @@ func TestPrototypeUse(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestPrototypeUse_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewPrototypeUse(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/registry_add_test.go
+++ b/pkg/actions/registry_add_test.go
@@ -100,3 +100,9 @@ func TestRegistryAdd(t *testing.T) {
 
 	})
 }
+
+func TestRegistryAdd_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewRegistryAdd(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/registry_describe_test.go
+++ b/pkg/actions/registry_describe_test.go
@@ -72,3 +72,9 @@ func TestRegistryDescribe(t *testing.T) {
 		assertOutput(t, "registry/describe/output.txt", buf.String())
 	})
 }
+
+func TestRegistryDescribe_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewRegistryDescribe(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/registry_list_test.go
+++ b/pkg/actions/registry_list_test.go
@@ -51,3 +51,9 @@ func TestRegistryList(t *testing.T) {
 		assertOutput(t, "registry/list/output.txt", buf.String())
 	})
 }
+
+func TestRegistryList_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewRegistryList(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/show_test.go
+++ b/pkg/actions/show_test.go
@@ -97,3 +97,9 @@ func TestShow_invalid_input(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestShow_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newShow(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/upgrade_test.go
+++ b/pkg/actions/upgrade_test.go
@@ -38,3 +38,9 @@ func TestUpgrade(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestUpgrade_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := newUpgrade(in)
+	require.Error(t, err)
+}

--- a/pkg/actions/validate_test.go
+++ b/pkg/actions/validate_test.go
@@ -108,6 +108,12 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidate_requires_app(t *testing.T) {
+	in := make(map[string]interface{})
+	_, err := NewValidate(in)
+	require.Error(t, err)
+}
+
 type stubDiscovery struct{}
 
 func (d *stubDiscovery) RESTClient() restclient.Interface {


### PR DESCRIPTION
If ks commands which require an app (everything except for `init`) are called, return an error informing the user of that situation.

Fixes #558

Signed-off-byr bryanl <bryanliles@gmail.com>