### PR TITLE
Add apiVersion/kind to app.override.yaml

### DIFF
--- a/pkg/app/base_app_test.go
+++ b/pkg/app/base_app_test.go
@@ -136,3 +136,15 @@ func Test_baseApp_load_override(t *testing.T) {
 	_, ok := ba.overrides.Registries["new"]
 	require.True(t, ok)
 }
+
+func Test_baseApp_load_override_invalid(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	stageFile(t, fs, "app010_app.yaml", "/app.yaml")
+	stageFile(t, fs, "add-registry-override-invalid.yaml", "/app.override.yaml")
+
+	ba := newBaseApp(fs, "/")
+
+	err := ba.load()
+	require.Error(t, err)
+}

--- a/pkg/app/encoder.go
+++ b/pkg/app/encoder.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"io"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+)
+
+// Encoder writes items to a serialized form.
+type Encoder interface {
+	// Encode writes an item to a stream. Implementations may return errors
+	// if the data to be encoded is invalid.
+	Encode(i interface{}, w io.Writer) error
+}
+
+var (
+	defaultYAMLEncoder = &YAMLEncoder{}
+)
+
+// YAMLEncoder write items to a serialized form in YAML format.
+type YAMLEncoder struct{}
+
+// Encode encodes data in yaml format.
+func (e *YAMLEncoder) Encode(i interface{}, w io.Writer) error {
+	b, err := yaml.Marshal(i)
+	if err != nil {
+		return errors.Wrap(err, "encoding data")
+	}
+
+	_, err = w.Write(b)
+	return err
+}

--- a/pkg/app/override.go
+++ b/pkg/app/override.go
@@ -15,8 +15,63 @@
 
 package app
 
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+const (
+	// overrideKind is the override resource type.
+	overrideKind = "ksonnet.io/app-override"
+	// overrideVersion is the version of the override resource.
+	overrideVersion = "0.1.0"
+)
+
 // Override defines overrides to ksonnet project configurations.
 type Override struct {
+	Kind         string           `json:"kind"`
+	APIVersion   string           `json:"apiVersion"`
 	Environments EnvironmentSpecs `json:"environments,omitempty"`
 	Registries   RegistryRefSpecs `json:"registries,omitempty"`
+}
+
+// Validate validates an Override.
+func (o *Override) Validate() error {
+	if o.Kind != overrideKind {
+		return errors.Errorf("app override has unexpected kind")
+	}
+
+	if o.APIVersion != overrideVersion {
+		return errors.Errorf("app override has unexpected apiVersion")
+	}
+
+	return nil
+}
+
+// IsDefined returns true if the override has environments or registries defined.
+func (o *Override) IsDefined() bool {
+	return len(o.Environments) > 0 || len(o.Registries) > 0
+}
+
+// SaveOverride saves the override to the filesystem.
+func SaveOverride(encoder Encoder, fs afero.Fs, root string, o *Override) error {
+	if o == nil {
+		return errors.New("override was nil")
+	}
+
+	o.APIVersion = overrideVersion
+	o.Kind = overrideKind
+
+	f, err := fs.OpenFile(overridePath(root), os.O_WRONLY|os.O_CREATE, DefaultFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	if err := encoder.Encode(o, f); err != nil {
+		return errors.Wrap(err, "encoding override")
+	}
+
+	return nil
 }

--- a/pkg/app/override_test.go
+++ b/pkg/app/override_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"io"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverride_Validate(t *testing.T) {
+	cases := []struct {
+		name  string
+		o     Override
+		isErr bool
+	}{
+		{
+			name: "valid override",
+			o:    Override{Kind: overrideKind, APIVersion: overrideVersion},
+		},
+		{
+			name:  "missing kind",
+			o:     Override{APIVersion: overrideVersion},
+			isErr: true,
+		},
+		{
+			name:  "invalid kind",
+			o:     Override{Kind: "invalid", APIVersion: overrideVersion},
+			isErr: true,
+		},
+		{
+			name:  "missing version",
+			o:     Override{Kind: overrideKind},
+			isErr: true,
+		},
+		{
+			name:  "invalid version",
+			o:     Override{APIVersion: "invalid", Kind: overrideKind},
+			isErr: true,
+		},
+		{
+			name:  "missing kind and version",
+			o:     Override{},
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.o.Validate()
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSaveOverride(t *testing.T) {
+	cases := []struct {
+		name    string
+		o       *Override
+		encoder Encoder
+		isErr   bool
+	}{
+		{
+			name:    "save override",
+			o:       &Override{},
+			encoder: defaultYAMLEncoder,
+		},
+		{
+			name:    "encode error",
+			o:       &Override{},
+			encoder: &failEncoder{},
+			isErr:   true,
+		},
+		{
+			name:  "override is nil",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+
+			err := SaveOverride(tc.encoder, fs, "/", tc.o)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+type failEncoder struct{}
+
+func (e *failEncoder) Encode(interface{}, io.Writer) error {
+	return errors.Errorf("fail")
+}

--- a/pkg/app/testdata/add-registry-override-invalid.yaml
+++ b/pkg/app/testdata/add-registry-override-invalid.yaml
@@ -1,5 +1,3 @@
-apiVersion: 0.1.0
-kind: ksonnet.io/app-override
 registries:
   new:
     protocol: ""

--- a/pkg/app/testdata/write-override.yaml
+++ b/pkg/app/testdata/write-override.yaml
@@ -1,8 +1,10 @@
+apiVersion: 0.1.0
 environments:
   b:
     destination: null
     k8sVersion: ""
     path: ""
+kind: ksonnet.io/app-override
 registries:
   b:
     protocol: ""


### PR DESCRIPTION
Adds identifying information to app override configuration

example:

```
apiVersion: 0.1.0
kind: ksonnet.io/app-override
registries:
  container:
    protocol: fs
    uri: ../../../../../../Development/heptio/ksonnet-container
```

Fixes #513

Signed-off-by: bryanl <bryanliles@gmail.com>