### PR TITLE
bugs: ksonnet lib printer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,8 +427,8 @@
     "ksonnet-gen/nodemaker",
     "ksonnet-gen/printer"
   ]
-  revision = "dda11dd2ec3928cbb7f36830ec0d8aa5fb13ce0c"
-  version = "v0.1.5"
+  revision = "863b9da5f131177b6bf7c0678a8d5ff909956b0e"
+  version = "v0.1.7"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -1267,6 +1267,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d54e717c9705768768030c1d16e15347c44b0b4edb40dc2a1d7caafd34f50311"
+  inputs-digest = "88a763c70a9571fdacc12685c647c669f746dde769ed278b9f3acbe490063ce9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = ["k8s.io/kubernetes/pkg/kubectl/cmd/util"]
 
 [[constraint]]
   name = "github.com/ksonnet/ksonnet-lib"
-  version = "v0.1.5"
+  version = "v0.1.7"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/metadata/params/testdata/delete-env-param/expected1.libsonnet
+++ b/metadata/params/testdata/delete-env-param/expected1.libsonnet
@@ -3,7 +3,7 @@ local params = {};
 params + {
   components+: {
     foo+: {
-      replicas: 1
-    }
-  }
+      replicas: 1,
+    },
+  },
 }

--- a/metadata/params/testdata/delete-env-param/expected2.libsonnet
+++ b/metadata/params/testdata/delete-env-param/expected2.libsonnet
@@ -3,7 +3,7 @@ local params = {};
 params {
   components+: {
     foo+: {
-      replicas: 1
-    }
-  }
+      replicas: 1,
+    },
+  },
 }

--- a/pkg/app/encoder.go
+++ b/pkg/app/encoder.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package app
 
 import (

--- a/pkg/app/override_test.go
+++ b/pkg/app/override_test.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package app
 
 import (

--- a/pkg/component/testdata/delete-env-params.libsonnet
+++ b/pkg/component/testdata/delete-env-params.libsonnet
@@ -1,5 +1,5 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params {
-  components+: {}
+  components+: {},
 }

--- a/pkg/component/testdata/guestbook/delete-params.libsonnet
+++ b/pkg/component/testdata/guestbook/delete-params.libsonnet
@@ -5,13 +5,13 @@
     // Each object below should correspond to a component in the components/ directory
     "guestbook-ui": {
       containerPort: 80,
-      image: "gcr.io/heptio-images/ks-guestbook-demo:0.1",
-      name: "guiroot",
+      image: 'gcr.io/heptio-images/ks-guestbook-demo:0.1',
+      name: 'guiroot',
       obj: {
-        a: "b"
+        a: 'b',
       },
       servicePort: 80,
-      type: "ClusterIP"
-    }
-  }
+      type: 'ClusterIP',
+    },
+  },
 }

--- a/pkg/component/testdata/guestbook/set-params.libsonnet
+++ b/pkg/component/testdata/guestbook/set-params.libsonnet
@@ -5,14 +5,14 @@
     // Each object below should correspond to a component in the components/ directory
     "guestbook-ui": {
       containerPort: 80,
-      image: "gcr.io/heptio-images/ks-guestbook-demo:0.1",
-      name: "guiroot",
+      image: 'gcr.io/heptio-images/ks-guestbook-demo:0.1',
+      name: 'guiroot',
       obj: {
-        a: "b"
+        a: 'b',
       },
       replicas: 4,
       servicePort: 80,
-      type: "ClusterIP"
-    }
-  }
+      type: 'ClusterIP',
+    },
+  },
 }

--- a/pkg/component/testdata/params-delete-entry.libsonnet
+++ b/pkg/component/testdata/params-delete-entry.libsonnet
@@ -4,7 +4,7 @@
     // Component-level parameters, defined initially from 'ks prototype use ...'
     // Each object below should correspond to a component in the components/ directory
     "certificate-crd": {
-      spec: {}
-    }
-  }
+      spec: {},
+    },
+  },
 }

--- a/pkg/component/testdata/params-delete-global.libsonnet
+++ b/pkg/component/testdata/params-delete-global.libsonnet
@@ -5,9 +5,9 @@
       other: 1,
       metadata: {
         labels: {
-          locala: "local"
-        }
-      }
-    }
-  }
+          locala: 'local',
+        },
+      },
+    },
+  },
 }

--- a/pkg/component/testdata/updated-yaml-params.libsonnet
+++ b/pkg/component/testdata/updated-yaml-params.libsonnet
@@ -3,8 +3,8 @@
   components: {
     "certificate-crd": {
       spec: {
-        version: "v2"
-      }
-    }
-  }
+        version: 'v2',
+      },
+    },
+  },
 }

--- a/pkg/env/testdata/add-global.libsonnet
+++ b/pkg/env/testdata/add-global.libsonnet
@@ -1,3 +1,3 @@
 {
-  foo: "bar"
+  foo: 'bar',
 }

--- a/pkg/env/testdata/delete-params.libsonnet
+++ b/pkg/env/testdata/delete-params.libsonnet
@@ -1,7 +1,7 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params + {
   components+: {
-    component1+: {}
-  }
+    component1+: {},
+  },
 }

--- a/pkg/env/testdata/params.libsonnet
+++ b/pkg/env/testdata/params.libsonnet
@@ -1,8 +1,8 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 params + {
   components +: {
     component1 +: {
-      foo: "bar",
+      foo: 'bar',
     },
   },
 }

--- a/pkg/env/testdata/updated-params.libsonnet
+++ b/pkg/env/testdata/updated-params.libsonnet
@@ -1,9 +1,9 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params + {
   components+: {
     component1+: {
-      foo: "bar"
-    }
-  }
+      foo: 'bar',
+    },
+  },
 }

--- a/pkg/params/testdata/env/globals/remove-component/out.libsonnet
+++ b/pkg/params/testdata/env/globals/remove-component/out.libsonnet
@@ -1,11 +1,12 @@
-local params = std.extVar("__ksonnet/params");
-local globals = import "globals.libsonnet";
+local params = std.extVar('__ksonnet/params');
+local globals = import 'globals.libsonnet';
 local envParams = params + {
-  components+: {}
+  components+: {},
 };
 
 {
   components: {
-    [x]: envParams.components[x] + globals for x in std.objectFields(envParams.components)
-  }
+    [x]: envParams.components[x] + globals
+    for x in std.objectFields(envParams.components)
+  },
 }

--- a/pkg/params/testdata/env/globals/set-global/out.libsonnet
+++ b/pkg/params/testdata/env/globals/set-global/out.libsonnet
@@ -1,1 +1,1 @@
-{group: "dev"}
+{ group: 'dev' }

--- a/pkg/params/testdata/env/globals/set/out-new-component.libsonnet
+++ b/pkg/params/testdata/env/globals/set/out-new-component.libsonnet
@@ -1,19 +1,20 @@
-local params = std.extVar("__ksonnet/params");
-local globals = import "globals.libsonnet";
+local params = std.extVar('__ksonnet/params');
+local globals = import 'globals.libsonnet';
 local envParams = params + {
   components+: {
     guestbook+: {
-      name: "guestbook-dev",
-      replicas: params.global.replicas
+      name: 'guestbook-dev',
+      replicas: params.global.replicas,
     },
     component+: {
-      name: "new-component"
-    }
-  }
+      name: 'new-component',
+    },
+  },
 };
 
 {
   components: {
-    [x]: envParams.components[x] + globals for x in std.objectFields(envParams.components)
-  }
+    [x]: envParams.components[x] + globals
+    for x in std.objectFields(envParams.components)
+  },
 }

--- a/pkg/params/testdata/env/globals/set/out.libsonnet
+++ b/pkg/params/testdata/env/globals/set/out.libsonnet
@@ -1,17 +1,18 @@
-local params = std.extVar("__ksonnet/params");
-local globals = import "globals.libsonnet";
+local params = std.extVar('__ksonnet/params');
+local globals = import 'globals.libsonnet';
 local envParams = params + {
   components+: {
     guestbook+: {
-      name: "guestbook-dev",
+      name: 'guestbook-dev',
       replicas: params.global.replicas,
-      containerPort: 8080
-    }
-  }
+      containerPort: 8080,
+    },
+  },
 };
 
 {
   components: {
-    [x]: envParams.components[x] + globals for x in std.objectFields(envParams.components)
-  }
+    [x]: envParams.components[x] + globals
+    for x in std.objectFields(envParams.components)
+  },
 }

--- a/pkg/params/testdata/env/globals/unset/out.libsonnet
+++ b/pkg/params/testdata/env/globals/unset/out.libsonnet
@@ -1,15 +1,16 @@
-local params = std.extVar("__ksonnet/params");
-local globals = import "globals.libsonnet";
+local params = std.extVar('__ksonnet/params');
+local globals = import 'globals.libsonnet';
 local envParams = params + {
   components+: {
     guestbook+: {
-      name: "guestbook-dev"
-    }
-  }
+      name: 'guestbook-dev',
+    },
+  },
 };
 
 {
   components: {
-    [x]: envParams.components[x] + globals for x in std.objectFields(envParams.components)
-  }
+    [x]: envParams.components[x] + globals
+    for x in std.objectFields(envParams.components)
+  },
 }

--- a/pkg/params/testdata/env/no-globals/remove-component/out.libsonnet
+++ b/pkg/params/testdata/env/no-globals/remove-component/out.libsonnet
@@ -1,5 +1,5 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params + {
-  components+: {}
+  components+: {},
 }

--- a/pkg/params/testdata/env/no-globals/set/out.libsonnet
+++ b/pkg/params/testdata/env/no-globals/set/out.libsonnet
@@ -1,11 +1,11 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params + {
   components+: {
     guestbook+: {
-      name: "guestbook-dev",
+      name: 'guestbook-dev',
       replicas: params.global.replicas,
-      containerPort: 8080
-    }
-  }
+      containerPort: 8080,
+    },
+  },
 }

--- a/pkg/params/testdata/env/no-globals/unset/out.libsonnet
+++ b/pkg/params/testdata/env/no-globals/unset/out.libsonnet
@@ -1,9 +1,9 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params + {
   components+: {
     guestbook+: {
-      name: "guestbook-dev"
-    }
-  }
+      name: 'guestbook-dev',
+    },
+  },
 }

--- a/pkg/params/testdata/updated.libsonnet
+++ b/pkg/params/testdata/updated.libsonnet
@@ -1,17 +1,17 @@
 {
   global: {
-    "restart": false
+    restart: false,
   },
   // Component-level parameters, defined initially from 'ks prototype use ...'
   // Each object below should correspond to a component in the components/ directory
   components: {
     "guestbook-ui": {
       containerPort: 80,
-      image: "gcr.io/heptio-images/ks-guestbook-demo:0.2",
-      name: "guestbook-ui",
+      image: 'gcr.io/heptio-images/ks-guestbook-demo:0.2',
+      name: 'guestbook-ui',
       replicas: 5,
       servicePort: 80,
-      type: "NodePort"
-    }
-  }
+      type: 'NodePort',
+    },
+  },
 }

--- a/pkg/util/jsonnet/object_test.go
+++ b/pkg/util/jsonnet/object_test.go
@@ -51,7 +51,7 @@ func TestSet(t *testing.T) {
 			name:       "update existing field",
 			updatePath: []string{"a", "b", "c"},
 			update:     nm.NewInt(9).Node(),
-			expected:   "{\n  a:: {\n    b:: {\n      c:: 9\n    }\n  }\n}",
+			expected:   "{\n  a:: {\n    b:: {\n      c:: 9,\n    },\n  },\n}",
 		},
 		{
 			name:       "set map",
@@ -63,7 +63,7 @@ func TestSet(t *testing.T) {
 			name:       "set new field",
 			updatePath: []string{"a", "e"},
 			update:     nm.NewInt(9).Node(),
-			expected:   "{\n  a:: {\n    b:: {\n      c:: \"value\"\n    },\n    e: 9\n  }\n}",
+			expected:   "{\n  a:: {\n    b:: {\n      c:: 'value',\n    },\n    e: 9,\n  },\n}",
 		},
 		{
 			name:       "set object field to non object",

--- a/pkg/util/jsonnet/testdata/set-map.jsonnet
+++ b/pkg/util/jsonnet/testdata/set-map.jsonnet
@@ -1,14 +1,14 @@
 {
   a:: {
     b:: {
-      c:: "value"
+      c:: 'value',
     },
     d: {
       metadata: {
         labels: {
-          label: "label"
-        }
-      }
-    }
-  }
+          label: 'label',
+        },
+      },
+    },
+  },
 }

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/astext/astext.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/astext/astext.go
@@ -34,9 +34,9 @@ type Object struct {
 
 var (
 	// reFieldStr matches a field id that should be enclosed in quotes.
-	reFieldStr = regexp.MustCompile(`^[A-Za-z]+[A-Za-z0-9\-]*$`)
+	reFieldStr = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9\-]*$`)
 	// reField matches a field id.
-	reField = regexp.MustCompile(`^[A-Za-z]+[A-Za-z0-9]*$`)
+	reField = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9]*$`)
 )
 
 // CreateField creates an ObjectField with a name. If the name matches `reFieldStr`, it will

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/constructors.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/constructors.go
@@ -12,7 +12,7 @@ import (
 var (
 	// reCtorSetter is a regex that matches function names. It'll successfully
 	// match `withName`, `foo.withName`, and `foo.bar.withName`.
-	reCtorSetter = regexp.MustCompile(`((^.*?)\.)*(with\w+)$`)
+	reCtorSetter = regexp.MustCompile(`((^.*?)\.)*(with\w+|mixinInstance)$`)
 )
 
 func matchCtorSetter(in string) (string, string, error) {

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/custom_constructor.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/custom_constructor.go
@@ -94,7 +94,7 @@ var (
 		makeDescriptor("api", "core", "LimitRangeList"): objectList,
 		makeDescriptor("api", "core", "Namespace"): []constructor{
 			*newConstructor("new",
-				*newConstructorParam("name", "withName", nil)),
+				*newConstructorParam("name", "mixin.metadata.withName", nil)),
 		},
 		makeDescriptor("api", "core", "NamespaceList"):             objectList,
 		makeDescriptor("api", "core", "NodeList"):                  objectList,
@@ -132,7 +132,7 @@ var (
 				*newConstructorParam("port", "withPort", nil),
 				*newConstructorParam("targetPort", "withTargetPort", nil)),
 			*newConstructor("newNamed",
-				*newConstructorParam("name", "mixin.metadata.withName", nil),
+				*newConstructorParam("name", "withName", nil),
 				*newConstructorParam("port", "withPort", nil),
 				*newConstructorParam("targetPort", "withTargetPort", nil)),
 		},


### PR DESCRIPTION
This PR fixes two issues due to regressions in ksonnet-lib's jsonnet printer:

* Parameters do not support underscores in env field names
* Sometimes commas would be omitted when constructing jsonnet
* Fixes for printing field expressions and object comprehensions

Fixes #554 
Fixes #544
Fixes #571 