### PR TITLE
Panic when setting non-existing component param

### DIFF
--- a/pkg/actions/param_set.go
+++ b/pkg/actions/param_set.go
@@ -131,6 +131,10 @@ func (ps *ParamSet) setLocal(path []string, value interface{}) error {
 		return errors.Wrap(err, "could not find component")
 	}
 
+	if c == nil {
+		return errors.Errorf("unable to find component %s", ps.rawPath)
+	}
+
 	if err := c.SetParam(path, value); err != nil {
 		return errors.Wrap(err, "set param")
 	}

--- a/pkg/actions/param_set_test.go
+++ b/pkg/actions/param_set_test.go
@@ -54,6 +54,31 @@ func TestParamSet(t *testing.T) {
 	})
 }
 
+func TestParamSet_invalid_component(t *testing.T) {
+	withApp(t, func(appMock *amocks.App) {
+		componentName := "deployment"
+		path := "replicas"
+		value := "3"
+
+		in := map[string]interface{}{
+			OptionApp:   appMock,
+			OptionName:  componentName,
+			OptionPath:  path,
+			OptionValue: value,
+		}
+
+		a, err := NewParamSet(in)
+		require.NoError(t, err)
+
+		a.resolvePathFn = func(app.App, string) (component.Module, component.Component, error) {
+			return nil, nil, nil
+		}
+
+		err = a.Run()
+		require.Error(t, err)
+	})
+}
+
 func TestParamSet_asString(t *testing.T) {
 	withApp(t, func(appMock *amocks.App) {
 		componentName := "deployment"


### PR DESCRIPTION
Checks to see if there a component before trying to set the component.

Fixes #564

Signed-off-by: bryanl <bryanliles@gmail.com>