### PR TITLE
adding component selection for diff

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,8 +427,8 @@
     "ksonnet-gen/nodemaker",
     "ksonnet-gen/printer"
   ]
-  revision = "863b9da5f131177b6bf7c0678a8d5ff909956b0e"
-  version = "v0.1.7"
+  revision = "dfcaa3d01d0c4948cb596403c35e966c774f2678"
+  version = "v0.1.8"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -1267,6 +1267,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "88a763c70a9571fdacc12685c647c669f746dde769ed278b9f3acbe490063ce9"
+  inputs-digest = "113cd4f1995d7833f4da0f087a2e80b8f26295d15afcc91c2a7708df41a8696e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = ["k8s.io/kubernetes/pkg/kubectl/cmd/util"]
 
 [[constraint]]
   name = "github.com/ksonnet/ksonnet-lib"
-  version = "v0.1.7"
+  version = "v0.1.8"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/docs/cli-reference/ks_diff.md
+++ b/docs/cli-reference/ks_diff.md
@@ -72,6 +72,7 @@ ks diff dev -c redis
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+  -c, --component stringSlice          Name of a specific component
       --context string                 The name of the kubeconfig context to use
   -V, --ext-str stringSlice            Values of external variables
       --ext-str-file stringSlice       Read external variable from a file

--- a/pkg/actions/diff.go
+++ b/pkg/actions/diff.go
@@ -111,7 +111,7 @@ func (d *Diff) Run() error {
 				return err
 			}
 		case strings.HasPrefix(t, "-"):
-			diffRemoveColor.Fprintln(&buf, t)
+			_, err = diffRemoveColor.Fprintln(&buf, t)
 			if err != nil {
 				return err
 			}

--- a/pkg/actions/diff_test.go
+++ b/pkg/actions/diff_test.go
@@ -86,7 +86,7 @@ func TestDiff(t *testing.T) {
 				var buf bytes.Buffer
 				d.out = &buf
 
-				d.diffFn = func(a app.App, c *client.Config, l1 *diff.Location, l2 *diff.Location) (io.Reader, error) {
+				d.diffFn = func(a app.App, c *client.Config, components []string, l1 *diff.Location, l2 *diff.Location) (io.Reader, error) {
 					assert.Equal(t, tc.eLocation1, l1.String(), "location1")
 					assert.Equal(t, tc.eLocation2, l2.String(), "location2")
 

--- a/pkg/actions/import.go
+++ b/pkg/actions/import.go
@@ -54,7 +54,7 @@ type Import struct {
 	module string
 	path   string
 
-	createComponentFn func(a app.App, name, text string, p params.Params, templateType prototype.TemplateType) (string, error)
+	createComponentFn func(a app.App, module, name, text string, p params.Params, templateType prototype.TemplateType) (string, error)
 }
 
 // NewImport creates an instance of Import. `module` is the name of the component and
@@ -248,15 +248,15 @@ func (i *Import) createYAML(fileName, base, ext string) error {
 func (i *Import) createComponentFromData(name, data string, templateType prototype.TemplateType) error {
 	componentParams := params.Params{}
 
+	var moduleName string
 	switch i.module {
-	case "":
-	case "/":
-		name = fmt.Sprintf("/%s", name)
+	case "", "/":
+		// do nothing
 	default:
-		name = fmt.Sprintf("%s/%s", i.module, name)
+		moduleName = i.module
 	}
 
-	_, err := i.createComponentFn(i.app, name, data, componentParams, templateType)
+	_, err := i.createComponentFn(i.app, moduleName, name, data, componentParams, templateType)
 	if err != nil {
 		return errors.Wrap(err, "create component")
 	}
@@ -281,7 +281,7 @@ func (i *Import) createComponent(fileName, base, ext string, templateType protot
 
 	componentParams := params.Params{}
 
-	_, err = i.createComponentFn(i.app, sourcePath, string(contents), componentParams, templateType)
+	_, err = i.createComponentFn(i.app, i.module, sourcePath, string(contents), componentParams, templateType)
 	if err != nil {
 		return errors.Wrap(err, "create component")
 	}

--- a/pkg/actions/import_test.go
+++ b/pkg/actions/import_test.go
@@ -51,19 +51,18 @@ func TestImport_http(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		module := "/"
-
 		in := map[string]interface{}{
 			OptionApp:    appMock,
-			OptionModule: module,
+			OptionModule: "",
 			OptionPath:   ts.URL,
 		}
 
 		a, err := NewImport(in)
 		require.NoError(t, err)
 
-		a.createComponentFn = func(_ app.App, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
-			assert.Contains(t, name, "/service-my-service-")
+		a.createComponentFn = func(_ app.App, moduleName, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
+			assert.Contains(t, name, "service-my-service-")
+			assert.Equal(t, "", moduleName)
 			assert.Equal(t, string(serviceData), text)
 			assert.Equal(t, params.Params{}, p)
 			assert.Equal(t, prototype.YAML, templateType)
@@ -97,8 +96,9 @@ func TestImport_file(t *testing.T) {
 		a, err := NewImport(in)
 		require.NoError(t, err)
 
-		a.createComponentFn = func(_ app.App, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
-			assert.Contains(t, name, "/service-my-service-")
+		a.createComponentFn = func(_ app.App, moduleName, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
+			assert.Contains(t, name, "service-my-service-")
+			assert.Equal(t, "", moduleName)
 			assert.Equal(t, string(serviceData), text)
 			assert.Equal(t, params.Params{}, p)
 			assert.Equal(t, prototype.YAML, templateType)
@@ -131,8 +131,9 @@ func TestImport_directory(t *testing.T) {
 		a, err := NewImport(in)
 		require.NoError(t, err)
 
-		a.createComponentFn = func(_ app.App, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
-			assert.Contains(t, name, "/service-my-service-")
+		a.createComponentFn = func(_ app.App, moduleName, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
+			assert.Contains(t, name, "service-my-service-")
+			assert.Equal(t, "", moduleName)
 			assert.Equal(t, string(serviceData), text)
 			assert.Equal(t, params.Params{}, p)
 			assert.Equal(t, prototype.YAML, templateType)
@@ -159,7 +160,7 @@ func TestImport_invalid_file(t *testing.T) {
 		a, err := NewImport(in)
 		require.NoError(t, err)
 
-		a.createComponentFn = func(_ app.App, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
+		a.createComponentFn = func(_ app.App, moduleName, name, text string, p params.Params, templateType prototype.TemplateType) (string, error) {
 			return "", errors.New("invalid")
 		}
 

--- a/pkg/actions/prototype_preview.go
+++ b/pkg/actions/prototype_preview.go
@@ -121,6 +121,8 @@ func (pp *PrototypePreview) Run() error {
 func bindPrototypeParams(p *prototype.Prototype) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("preview", pflag.ContinueOnError)
 
+	fs.String("module", "", "Component module")
+
 	for _, param := range p.RequiredParams() {
 		fs.String(param.Name, "", param.Description)
 	}

--- a/pkg/actions/testdata/prototype/use/text.txt
+++ b/pkg/actions/testdata/prototype/use/text.txt
@@ -1,5 +1,5 @@
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components.myDeployment;
+local params = std.extVar("__ksonnet/params").components.deployment;
 {
    "apiVersion": "apps/v1beta1",
    "kind": "Deployment",

--- a/pkg/clicmd/diff.go
+++ b/pkg/clicmd/diff.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/ksonnet/ksonnet/pkg/actions"
 	"github.com/ksonnet/ksonnet/pkg/client"
@@ -27,6 +28,8 @@ import (
 
 const (
 	diffShortDesc = "Compare manifests, based on environment or location (local or remote)"
+
+	vDiffComponentNames = "diff-component-names"
 )
 
 var (
@@ -34,11 +37,12 @@ var (
 )
 
 func init() {
-	// addEnvCmdFlags(diffCmd)
-
 	diffClientConfig = client.NewDefaultClientConfig(ka)
 	diffClientConfig.BindClientGoFlags(diffCmd)
 	bindJsonnetFlags(diffCmd, "diff")
+
+	diffCmd.Flags().StringSliceP(flagComponent, shortComponent, nil, "Name of a specific component")
+	viper.BindPFlag(vDiffComponentNames, diffCmd.Flags().Lookup(flagComponent))
 
 	RootCmd.AddCommand(diffCmd)
 }
@@ -55,9 +59,10 @@ var diffCmd = &cobra.Command{
 		}
 
 		m := map[string]interface{}{
-			actions.OptionApp:          ka,
-			actions.OptionClientConfig: diffClientConfig,
-			actions.OptionSrc1:         args[0],
+			actions.OptionApp:            ka,
+			actions.OptionClientConfig:   diffClientConfig,
+			actions.OptionSrc1:           args[0],
+			actions.OptionComponentNames: viper.GetStringSlice(vDiffComponentNames),
 		}
 
 		if len(args) == 2 {

--- a/pkg/clicmd/diff_test.go
+++ b/pkg/clicmd/diff_test.go
@@ -28,10 +28,11 @@ func Test_diffCmd(t *testing.T) {
 			args:   []string{"diff", "env1", "env2"},
 			action: actionDiff,
 			expected: map[string]interface{}{
-				actions.OptionApp:          nil,
-				actions.OptionClientConfig: diffClientConfig,
-				actions.OptionSrc1:         "env1",
-				actions.OptionSrc2:         "env2",
+				actions.OptionApp:            nil,
+				actions.OptionClientConfig:   diffClientConfig,
+				actions.OptionSrc1:           "env1",
+				actions.OptionSrc2:           "env2",
+				actions.OptionComponentNames: []string{},
 			},
 		},
 	}

--- a/pkg/cluster/object_test.go
+++ b/pkg/cluster/object_test.go
@@ -281,7 +281,7 @@ func TestRebuildObject(t *testing.T) {
 
 func TestDefaultResourceInfo(t *testing.T) {
 	fcc := &fakeClientConfig{}
-	res := DefaultResourceInfo("default", fcc)
+	res := DefaultResourceInfo("default", fcc, []string{})
 
 	// NOTE: yes this errors.
 	require.Error(t, res.Err())

--- a/pkg/cluster/show_test.go
+++ b/pkg/cluster/show_test.go
@@ -106,3 +106,107 @@ func TestShow(t *testing.T) {
 		})
 	}
 }
+
+func Test_sortByKind(t *testing.T) {
+	objects := []*unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1beta2",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d3",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "s2",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d1",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "extensions/v1beta1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d2",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "s1",
+				},
+			},
+		},
+	}
+
+	for i := 0; i < 10; i++ {
+		sortByKind(objects)
+	}
+
+	expected := []*unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d1",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1beta2",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d3",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "extensions/v1beta1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "d2",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "s1",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "s2",
+				},
+			},
+		},
+	}
+
+	require.Equal(t, expected, objects)
+}

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -78,8 +78,9 @@ func Test_Create(t *testing.T) {
 			name:          "nested/component",
 			params:        params.Params{"name": "name"},
 			templateType:  prototype.Jsonnet,
-			componentName: "nested/component",
-			componentDir:  "/components/nested",
+			ns:            "nested",
+			componentName: "component",
+			componentDir:  "/components",
 		},
 	}
 
@@ -92,9 +93,7 @@ func Test_Create(t *testing.T) {
 			ksApp.On("Fs").Return(fs)
 			ksApp.On("Root").Return(root)
 
-			name := filepath.Join(tc.ns, tc.componentName)
-
-			path, err := Create(ksApp, name, "content", tc.params, tc.templateType)
+			path, err := Create(ksApp, tc.ns, tc.componentName, "content", tc.params, tc.templateType)
 			if tc.isErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/component/jsonnet.go
+++ b/pkg/component/jsonnet.go
@@ -18,7 +18,6 @@ package component
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -68,11 +67,11 @@ func (j *Jsonnet) Name(wantsNameSpaced bool) string {
 		return name
 	}
 
-	if j.module == "/" {
+	if j.module == "/" || j.module == "" {
 		return name
 	}
 
-	return path.Join(j.module, name)
+	return strings.Join([]string{j.module, name}, ".")
 }
 
 // Type always returns "jsonnet".
@@ -187,7 +186,7 @@ func (j *Jsonnet) ToNode(envName string) (string, ast.Node, error) {
 		return "", nil, err
 	}
 
-	return j.Name(false), n, nil
+	return j.Name(true), n, nil
 }
 
 func (j *Jsonnet) readParams(envName string) (string, error) {

--- a/pkg/component/jsonnet_test.go
+++ b/pkg/component/jsonnet_test.go
@@ -68,7 +68,7 @@ func TestJsonnet_Name(t *testing.T) {
 			{
 				name:         "nested: wants namespaced",
 				isNameSpaced: true,
-				expected:     "nested/guestbook-ui",
+				expected:     "nested.guestbook-ui",
 				c:            nested,
 			},
 			{

--- a/pkg/component/locator.go
+++ b/pkg/component/locator.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/ksonnet/ksonnet/pkg/app"
 	"github.com/pkg/errors"
@@ -61,7 +62,7 @@ func (cpl *componentPathLocator) Locate() ([]string, error) {
 	var paths []string
 
 	for _, target := range targets {
-		childPath := filepath.Join(rootPath, componentsRoot, target)
+		childPath := locateTarget(cpl.app.Root(), target)
 		exists, err := afero.DirExists(cpl.app.Fs(), childPath)
 		if err != nil {
 			return nil, err
@@ -77,6 +78,11 @@ func (cpl *componentPathLocator) Locate() ([]string, error) {
 	sort.Strings(paths)
 
 	return paths, nil
+}
+
+func locateTarget(rootPath, target string) string {
+	targetPath := strings.Replace(target, ".", string(filepath.Separator), -1)
+	return filepath.Join(rootPath, componentsRoot, targetPath)
 }
 
 func (cpl *componentPathLocator) allNamespaces() ([]string, error) {

--- a/pkg/component/locator_test.go
+++ b/pkg/component/locator_test.go
@@ -1,0 +1,39 @@
+package component
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_locateTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{
+			name:     "root path",
+			in:       ".",
+			expected: filepath.ToSlash("/components"),
+		},
+		{
+			name:     "nested path 1",
+			in:       "foo",
+			expected: filepath.ToSlash("/components/foo"),
+		},
+		{
+			name:     "nested path 2",
+			in:       "foo.bar",
+			expected: filepath.ToSlash("/components/foo/bar"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := locateTarget(filepath.FromSlash("/"), tc.in)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -67,18 +67,13 @@ func Test_ResolvePath(t *testing.T) {
 				cName:  "deployment",
 			},
 			{
-				name:   "/deployment",
+				name:   "deployment",
 				module: "/",
 				cName:  "deployment",
 			},
 			{
-				name:   "/nested/deployment",
-				module: "/nested",
-				cName:  "deployment",
-			},
-			{
 				name:   "nested/deployment",
-				module: "/nested",
+				module: "nested",
 				cName:  "deployment",
 			},
 			{

--- a/pkg/component/yaml.go
+++ b/pkg/component/yaml.go
@@ -18,7 +18,6 @@ package component
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -69,11 +68,11 @@ func (y *YAML) Name(wantsNameSpaced bool) string {
 		return name
 	}
 
-	if y.module == "/" {
+	if y.module == "/" || y.module == "" {
 		return name
 	}
 
-	return path.Join(y.module, name)
+	return strings.Join([]string{y.module, name}, ".")
 }
 
 // Type always returns "yaml".
@@ -322,7 +321,7 @@ func (y *YAML) ToNode(envName string) (string, ast.Node, error) {
 		return "", nil, err
 	}
 
-	return key, o, nil
+	return y.Name(true), o, nil
 }
 
 func (y *YAML) applyParams(componentName, data string) (string, error) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -25,6 +25,7 @@ import (
 	appmocks "github.com/ksonnet/ksonnet/pkg/app/mocks"
 	"github.com/ksonnet/ksonnet/pkg/component"
 	cmocks "github.com/ksonnet/ksonnet/pkg/component/mocks"
+	"github.com/ksonnet/ksonnet/pkg/metadata"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -118,6 +119,9 @@ func TestPipeline_Objects(t *testing.T) {
 					"apiVersion": "v1",
 					"kind":       "Service",
 					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							metadata.LabelComponent: "service",
+						},
 						"name": "my-service",
 					},
 					"spec": map[string]interface{}{

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/astext/astext.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/astext/astext.go
@@ -34,7 +34,7 @@ type Object struct {
 
 var (
 	// reFieldStr matches a field id that should be enclosed in quotes.
-	reFieldStr = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9\-]*$`)
+	reFieldStr = regexp.MustCompile(`^([_A-Za-z0-9\.]?[A-Za-z0-9\-_\.]+(\.[A-Za-z0-9\-_]+)*)?$`)
 	// reField matches a field id.
 	reField = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9]*$`)
 )


### PR DESCRIPTION
This change adds components for diffs. You can now run:

```
ks diff local:default remote:default -c <component name>
```

To diff a component in a module, specify the component with a module name. e.g component (for a module in the root component) or nested.component (for a module in nested/ under components)

In addition, module support throughout the ks was updated

* Modules allow ksonnet users to separate their configurations under components.
* Modules are dot separated paths that correlate to their location on the file system. e.g module a is in /app/components/a
* Modules can be deeply nested. e.g components in /app/components/nested/deeply would be in module nested.deeply
* Modules are now added as a label to kubernetes resources in `ksonnet.io/component`. This will allow the user to determine which component created a resource

Fixes #581

Signed-off-by: bryanl bryanliles@gmail.com