### PR TITLE
Add `--installed` flag to pkg list

### DIFF
--- a/docs/cli-reference/ks_pkg_list.md
+++ b/docs/cli-reference/ks_pkg_list.md
@@ -29,7 +29,8 @@ ks pkg list [flags]
 ### Options
 
 ```
-  -h, --help   help for list
+  -h, --help        help for list
+      --installed   Only list installed packages
 ```
 
 ### Options inherited from parent commands

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -61,6 +61,8 @@ const (
 	OptionGlobal = "global"
 	// OptionGracePeriod is gracePeriod option.
 	OptionGracePeriod = "grace-period"
+	// OptionInstalled is for listing installed packages.
+	OptionInstalled = "only-installed"
 	// OptionJPaths is jsonnet paths.
 	OptionJPaths = "jpaths"
 	// OptionLibName is libName.

--- a/pkg/actions/testdata/pkg/list/installed.txt
+++ b/pkg/actions/testdata/pkg/list/installed.txt
@@ -1,0 +1,3 @@
+REGISTRY  NAME INSTALLED
+========  ==== =========
+incubator lib1 *

--- a/pkg/clicmd/flags.go
+++ b/pkg/clicmd/flags.go
@@ -30,6 +30,7 @@ const (
 	flagFilename              = "filename"
 	flagGcTag                 = "gc-tag"
 	flagGracePeriod           = "grace-period"
+	flagInstalled             = "installed"
 	flagJpath                 = "jpath"
 	flagModule                = "module"
 	flagNamespace             = "namespace"

--- a/pkg/clicmd/pkg_list.go
+++ b/pkg/clicmd/pkg_list.go
@@ -18,8 +18,14 @@ package clicmd
 import (
 	"fmt"
 
+	"github.com/spf13/viper"
+
 	"github.com/ksonnet/ksonnet/pkg/actions"
 	"github.com/spf13/cobra"
+)
+
+const (
+	vPkgListInstalled = "pkg-list-installed"
 )
 
 var pkgListCmd = &cobra.Command{
@@ -31,7 +37,8 @@ var pkgListCmd = &cobra.Command{
 		}
 
 		m := map[string]interface{}{
-			actions.OptionApp: ka,
+			actions.OptionApp:       ka,
+			actions.OptionInstalled: viper.GetBool(vPkgListInstalled),
 		}
 
 		return runAction(actionPkgList, m)
@@ -57,4 +64,7 @@ the following info:
 
 func init() {
 	pkgCmd.AddCommand(pkgListCmd)
+
+	pkgListCmd.Flags().Bool(flagInstalled, false, "Only list installed packages")
+	viper.BindPFlag(vPkgListInstalled, pkgListCmd.Flags().Lookup(flagInstalled))
 }

--- a/pkg/clicmd/pkg_list_test.go
+++ b/pkg/clicmd/pkg_list_test.go
@@ -28,7 +28,8 @@ func Test_pkgListCmd(t *testing.T) {
 			args:   []string{"pkg", "list"},
 			action: actionPkgList,
 			expected: map[string]interface{}{
-				actions.OptionApp: ka,
+				actions.OptionApp:       ka,
+				actions.OptionInstalled: false,
 			},
 		},
 	}


### PR DESCRIPTION
Adds a new flag to `pkg list` that only lists installed packages.

![2018-06-07_21-43-24](https://user-images.githubusercontent.com/240/41134708-d4f6efb8-6a9b-11e8-9aad-da72e0ead7e4.png)


Signed-off-by: bryanl <bryanliles@gmail.com>