### PR TITLE
Remove global client config for init

### DIFF
--- a/pkg/clicmd/env.go
+++ b/pkg/clicmd/env.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -129,7 +130,7 @@ func commonEnvFlags(flags *pflag.FlagSet) (server, namespace, context string, er
 	return server, namespace, context, nil
 }
 
-func resolveEnvFlags(flags *pflag.FlagSet) (string, string, error) {
+func resolveEnvFlags(flags *pflag.FlagSet, config *client.Config) (string, string, error) {
 	defaultNamespace := "default"
 
 	server, envNs, context, err := commonEnvFlags(flags)
@@ -140,7 +141,7 @@ func resolveEnvFlags(flags *pflag.FlagSet) (string, string, error) {
 	var ctxNs string
 	if server == "" {
 		// server is not provided -- use the context.
-		server, ctxNs, err = envClientConfig.ResolveContext(context)
+		server, ctxNs, err = config.ResolveContext(context)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/clicmd/env_add.go
+++ b/pkg/clicmd/env_add.go
@@ -31,8 +31,7 @@ const (
 )
 
 var (
-	envClientConfig *client.Config
-	envAddLong      = `
+	envAddLong = `
 The ` + "`add`" + ` command creates a new environment (specifically for the ksonnet app
 whose directory it's executed in). This environment is cached with the following
 info:
@@ -98,7 +97,7 @@ func newEnvAddCmd(a app.App) *cobra.Command {
 
 			name := args[0]
 
-			server, namespace, err := resolveEnvFlags(flags)
+			server, namespace, err := resolveEnvFlags(flags, envClientConfig)
 			if err != nil {
 				return err
 			}

--- a/pkg/clicmd/init.go
+++ b/pkg/clicmd/init.go
@@ -127,7 +127,9 @@ func newInitCmd(fs afero.Fs, wd string) *cobra.Command {
 				return err
 			}
 
-			server, namespace, err := resolveEnvFlags(flags)
+			clientConfig := client.NewDefaultClientConfig(nil)
+
+			server, namespace, err := resolveEnvFlags(flags, clientConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Continuing to remove reliance on globals

Signed-off-by: bryanl <bryanliles@gmail.com>