### PR TITLE
move/upgrade ks lib location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 VERSION?=dev-$(shell date +%FT%T%z)
 KS_BIN?=ks
 
-APIMACHINERY_VER := $(shell grep -B1 k8s.io/apimachinery Gopkg.lock | head -n1 | cut -d'"' -f2)
+APIMACHINERY_VER := $(shell grep -A100 k8s.io/apimachinery Gopkg.lock | grep -m1 "version =" | cut -d'"' -f2)
 REVISION=$(shell git rev-parse HEAD)
 GIT_TAG=$(shell git describe --tags)
 

--- a/pkg/actions/env_update.go
+++ b/pkg/actions/env_update.go
@@ -85,5 +85,5 @@ func genLib(a app.App, k8sSpecFlag, libPath string) error {
 		return err
 	}
 
-	return libManager.GenerateLibData(false)
+	return libManager.GenerateLibData()
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -124,13 +124,13 @@ func Load(fs afero.Fs, cwd string, skipFindRoot bool) (App, error) {
 	}
 }
 
-func updateLibData(fs afero.Fs, k8sSpecFlag, libPath string, useVersionPath bool) (string, error) {
+func updateLibData(fs afero.Fs, k8sSpecFlag, libPath string) (string, error) {
 	lm, err := lib.NewManager(k8sSpecFlag, fs, libPath)
 	if err != nil {
 		return "", err
 	}
 
-	if err := lm.GenerateLibData(useVersionPath); err != nil {
+	if err := lm.GenerateLibData(); err != nil {
 		return "", err
 	}
 
@@ -142,7 +142,7 @@ func app010LibPath(root string) string {
 }
 
 // StubUpdateLibData always returns no error.
-func StubUpdateLibData(fs afero.Fs, k8sSpecFlag, libPath string, useVersionPath bool) (string, error) {
+func StubUpdateLibData(fs afero.Fs, k8sSpecFlag, libPath string) (string, error) {
 	return "v1.8.7", nil
 }
 

--- a/pkg/app/app001.go
+++ b/pkg/app/app001.go
@@ -73,7 +73,7 @@ func (a *App001) AddEnvironment(name, k8sSpecFlag string, spec *EnvironmentSpec,
 		return err
 	}
 
-	_, err = LibUpdater(a.fs, k8sSpecFlag, a.appLibPath(name), false)
+	_, err = LibUpdater(a.fs, k8sSpecFlag, a.appLibPath(name))
 	return err
 }
 
@@ -287,7 +287,7 @@ func (a *App001) convertEnvironment(envName string, dryRun bool) error {
 	}
 
 	k8sSpecFlag := fmt.Sprintf("version:%s", env.KubernetesVersion)
-	_, err = LibUpdater(a.fs, k8sSpecFlag, app010LibPath(a.root), true)
+	_, err = LibUpdater(a.fs, k8sSpecFlag, app010LibPath(a.root))
 	if err != nil {
 		return err
 	}

--- a/pkg/app/app001_test.go
+++ b/pkg/app/app001_test.go
@@ -253,7 +253,7 @@ func TestApp001_UpdateTargets(t *testing.T) {
 
 func withApp001Fs(t *testing.T, appName string, fn func(app *App001)) {
 	ogLibUpdater := LibUpdater
-	LibUpdater = func(fs afero.Fs, k8sSpecFlag string, libPath string, useVersionPath bool) (string, error) {
+	LibUpdater = func(fs afero.Fs, k8sSpecFlag string, libPath string) (string, error) {
 		path := filepath.Join(libPath, "swagger.json")
 		stageFile(t, fs, "swagger.json", path)
 		return "v1.8.7", nil

--- a/pkg/app/app010_test.go
+++ b/pkg/app/app010_test.go
@@ -177,7 +177,7 @@ func TestApp0101_LibPath(t *testing.T) {
 		path, err := app.LibPath("default")
 		require.NoError(t, err)
 
-		expected := filepath.Join("/", "lib", "v1.7.0")
+		expected := filepath.Join("/", "lib", "ksonnet-lib", "v1.7.0")
 		require.Equal(t, expected, path)
 	})
 }
@@ -263,10 +263,81 @@ func TestApp010_RenameEnvironment(t *testing.T) {
 }
 
 func TestApp010_Upgrade(t *testing.T) {
-	withApp010Fs(t, "app010_app.yaml", func(app *App010) {
-		err := app.Upgrade(false)
-		require.NoError(t, err)
-	})
+	cases := []struct {
+		name         string
+		init         func(t *testing.T, app *App010)
+		checkUpgrade func(t *testing.T, app *App010)
+		dryRun       bool
+		isErr        bool
+	}{
+		{
+			name: "ksonnet lib doesn't need to be upgraded",
+			init: func(t *testing.T, app *App010) {
+				err := app.Fs().MkdirAll("/lib", DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(app.Root(), "lib", "ksonnet-lib", "v1.10.3")
+				err = app.Fs().MkdirAll(p, DefaultFolderPermissions)
+				require.NoError(t, err)
+			},
+			dryRun: false,
+		},
+		{
+			name: "ksonnet lib needs to be upgraded",
+			init: func(t *testing.T, app *App010) {
+				err := app.Fs().MkdirAll("/lib", DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(app.Root(), "lib", "v1.10.3")
+				err = app.Fs().MkdirAll(p, DefaultFolderPermissions)
+				require.NoError(t, err)
+			},
+			dryRun: false,
+		},
+		{
+			name: "ksonnet lib needs to be upgraded - dry run",
+			init: func(t *testing.T, app *App010) {
+				err := app.Fs().MkdirAll("/lib", DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(app.Root(), "lib", "v1.10.3")
+				err = app.Fs().MkdirAll(p, DefaultFolderPermissions)
+				require.NoError(t, err)
+			},
+			checkUpgrade: func(t *testing.T, app *App010) {
+				isDir, err := afero.IsDir(app.Fs(), filepath.Join("/lib", "v1.10.3"))
+				require.NoError(t, err)
+				require.True(t, isDir)
+			},
+			dryRun: true,
+		},
+		{
+			name:  "lib doesn't exist",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withApp010Fs(t, "app010_app.yaml", func(app *App010) {
+				if tc.init != nil {
+					tc.init(t, app)
+				}
+
+				err := app.Upgrade(tc.dryRun)
+				if tc.isErr {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+
+				if tc.checkUpgrade != nil {
+					tc.checkUpgrade(t, app)
+				}
+			})
+		})
+	}
 }
 
 func TestApp0101_UpdateTargets(t *testing.T) {
@@ -284,7 +355,7 @@ func TestApp0101_UpdateTargets(t *testing.T) {
 
 func withApp010Fs(t *testing.T, appName string, fn func(app *App010)) {
 	ogLibUpdater := LibUpdater
-	LibUpdater = func(fs afero.Fs, k8sSpecFlag string, libPath string, useVersionPath bool) (string, error) {
+	LibUpdater = func(fs afero.Fs, k8sSpecFlag string, libPath string) (string, error) {
 		return "v1.8.7", nil
 	}
 

--- a/pkg/appinit/init_test.go
+++ b/pkg/appinit/init_test.go
@@ -137,7 +137,7 @@ func assertExists(t *testing.T, fs afero.Fs, path string) {
 func assertLib(t *testing.T, fs afero.Fs, root, version string) {
 	files := []string{"swagger.json", "k.libsonnet", "k8s.libsonnet"}
 	for _, f := range files {
-		path := filepath.Join(root, "lib", version, f)
+		path := filepath.Join(root, "lib", "ksonnet-lib", version, f)
 		assertExists(t, fs, path)
 	}
 }

--- a/pkg/lib/clusterspec_test.go
+++ b/pkg/lib/clusterspec_test.go
@@ -30,7 +30,7 @@ type parseSuccess struct {
 
 func TestClusterSpecParsingSuccess(t *testing.T) {
 	testFS := afero.NewMemMapFs()
-	afero.WriteFile(testFS, blankSwagger, []byte(blankSwaggerData), os.ModePerm)
+	afero.WriteFile(testFS, swaggerLocation, []byte(blankSwaggerData), os.ModePerm)
 
 	var successTests = []parseSuccess{
 		{"version:v1.7.1", &clusterSpecVersion{"v1.7.1"}},
@@ -89,7 +89,7 @@ func TestClusterSpecParsingFailure(t *testing.T) {
 
 	for _, test := range failureTests {
 		testFS := afero.NewMemMapFs()
-		afero.WriteFile(testFS, blankSwagger, []byte(blankSwaggerData), os.ModePerm)
+		afero.WriteFile(testFS, swaggerLocation, []byte(blankSwaggerData), os.ModePerm)
 		_, err := ParseClusterSpec(test.input, testFS)
 		if err == nil {
 			t.Errorf("Cluster spec parse for '%s' should have failed, but succeeded", test.input)


### PR DESCRIPTION
Moving generated ksonnet lib from lib/<verson> to lib/ksonnet-lib/<version>.
This change will free up lib to be used for other lib type things.

Ksonnet will warn if ksonnet-lib is in the legacy location and the
user can use `ks upgrade` to move the files to their new location.

Also:

* update Makefile to search harder for apimachiner revision

Fixes #512