### PR TITLE
Shift to ServerVersion call to get version

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/ksonnet/ksonnet/pkg/app"
 	str "github.com/ksonnet/ksonnet/pkg/util/strings"
@@ -93,13 +94,14 @@ func (c *Config) GetAPISpec() string {
 		return defaultVersion
 	}
 
-	openAPIDoc, err := dc.OpenAPISchema()
+	serverVersion, err := dc.ServerVersion()
 	if err != nil {
-		log.WithError(err).Debug("Failed to retrieve OpenAPI schema")
+		log.WithError(err).Debug("Failed to retrieve kubernetes server version")
 		return defaultVersion
 	}
 
-	return fmt.Sprintf("version:%s", openAPIDoc.Info.Version)
+	k8sAPISpec := fmt.Sprintf("version:%s", serverVersion)
+	return strings.Split(k8sAPISpec, "+")[0]
 }
 
 // Namespace returns the namespace for the provided ClientConfig.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -46,6 +46,11 @@ func TestConfig_GetAPISpec(t *testing.T) {
 		{
 			name:    "with dev version",
 			version: "version:v1.9.3",
+			disc:    &fakeDiscovery{withVersion: "v1.9.3-fadecafe"},
+		},
+		{
+			name:    "with dev version",
+			version: "version:v1.9.3",
 			disc:    &fakeDiscovery{withVersion: "v1.9.3+facade"},
 		},
 		{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -41,7 +41,12 @@ func TestConfig_GetAPISpec(t *testing.T) {
 		{
 			name:    "in general",
 			version: "version:v1.9.3",
-			disc:    &fakeDiscovery{},
+			disc:    &fakeDiscovery{withVersion: "v1.9.3"},
+		},
+		{
+			name:    "with dev version",
+			version: "version:v1.9.3",
+			disc:    &fakeDiscovery{withVersion: "v1.9.3+facade"},
 		},
 		{
 			name:      "unable to create discovery client",
@@ -51,7 +56,7 @@ func TestConfig_GetAPISpec(t *testing.T) {
 		{
 			name:    "retrieve open api schema error",
 			version: "version:v1.8.0",
-			disc:    &fakeDiscovery{withOpenAPISchemaError: true},
+			disc:    &fakeDiscovery{withError: true},
 		},
 	}
 
@@ -96,7 +101,8 @@ func (c *clientConfig) ConfigAccess() clientcmd.ConfigAccess {
 }
 
 type fakeDiscovery struct {
-	withOpenAPISchemaError bool
+	withError   bool
+	withVersion string
 }
 
 var _ discovery.DiscoveryInterface = (*fakeDiscovery)(nil)
@@ -122,19 +128,17 @@ func (c *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 }
 
 func (c *fakeDiscovery) ServerVersion() (*version.Info, error) {
-	return nil, errors.New("not implemented")
+	if c.withError {
+		return nil, errors.New("server version error")
+	}
+
+	return &version.Info{
+		GitVersion: c.withVersion,
+	}, nil
 }
 
 func (c *fakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
-	if c.withOpenAPISchemaError {
-		return nil, errors.New("schema error")
-	}
-
-	return &openapi_v2.Document{
-		Info: &openapi_v2.Info{
-			Version: "v1.9.3",
-		},
-	}, nil
+	return nil, errors.New("not implemented")
 }
 
 func (c *fakeDiscovery) SwaggerSchema(version schema.GroupVersion) (*swagger.ApiDeclaration, error) {


### PR DESCRIPTION
instead of using OpenAPISchema for version because openshift stores its
own version data in Info.Version

this only addresses the app init section - there are other places where version info could be gathered for environments that will need to be addressed as well. before i head down that road i'm pushing this to check and see if this is the right direction to move in - which is why it's WIP right now.

related to #427 