### PR TITLE
Use values file for prototype use/preview

### DIFF
--- a/docs/cli-reference/ks_generate.md
+++ b/docs/cli-reference/ks_generate.md
@@ -65,6 +65,12 @@ ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
 ks prototype use deployment nginx-depl \
   --name=nginx                         \
   --image=nginx
+
+# Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
+# 'nginx' image with values from 'ks-value'.
+ks prototype use single-port-deployment nginx-depl \
+  --values-file=ks-value
+
 ```
 
 ### Options

--- a/docs/cli-reference/ks_prototype_preview.md
+++ b/docs/cli-reference/ks_prototype_preview.md
@@ -33,6 +33,20 @@ ks prototype preview single-port-deployment \
   --name=nginx                              \
   --image=nginx                             \
   --port=80
+
+# Preview prototype 'io.ksonnet.pkg.single-port-deployment', using the
+# 'nginx' image, and port 80 exposed with a values file.
+ks prototype preview simple-port-deployment \
+  --name=nginx                              \
+  --values-file=ks-values
+
+Where 'ks-values' is a jsonnet file with the contents:
+
+{
+	image: "nginx",
+	port: 80,
+}
+
 ```
 
 ### Options

--- a/docs/cli-reference/ks_prototype_use.md
+++ b/docs/cli-reference/ks_prototype_use.md
@@ -65,6 +65,12 @@ ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
 ks prototype use deployment nginx-depl \
   --name=nginx                         \
   --image=nginx
+
+# Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
+# 'nginx' image with values from 'ks-value'.
+ks prototype use single-port-deployment nginx-depl \
+  --values-file=ks-value
+
 ```
 
 ### Options

--- a/pkg/clicmd/prototype_preview.go
+++ b/pkg/clicmd/prototype_preview.go
@@ -44,7 +44,21 @@ a component with ` + "`ks generate`" + ` and then use ` + "`ks show`" + `.
 ks prototype preview single-port-deployment \
   --name=nginx                              \
   --image=nginx                             \
-  --port=80`
+  --port=80
+
+# Preview prototype 'io.ksonnet.pkg.single-port-deployment', using the
+# 'nginx' image, and port 80 exposed with a values file.
+ks prototype preview simple-port-deployment \
+  --name=nginx                              \
+  --values-file=ks-values
+
+Where 'ks-values' is a jsonnet file with the contents:
+
+{
+	image: "nginx",
+	port: 80,
+}
+`
 )
 
 func newPrototypePreviewCmd(a app.App) *cobra.Command {

--- a/pkg/clicmd/prototype_use.go
+++ b/pkg/clicmd/prototype_use.go
@@ -75,7 +75,13 @@ ks prototype use io.ksonnet.pkg.single-port-deployment nginx-depl \
 # (due to --name).
 ks prototype use deployment nginx-depl \
   --name=nginx                         \
-  --image=nginx`
+  --image=nginx
+
+# Instantiate prototype 'io.ksonnet.pkg.single-port-deployment' using the
+# 'nginx' image with values from 'ks-value'.
+ks prototype use single-port-deployment nginx-depl \
+  --values-file=ks-value
+`
 )
 
 func newGenerateCmd(a app.App) *cobra.Command {

--- a/pkg/prototype/flags.go
+++ b/pkg/prototype/flags.go
@@ -18,6 +18,9 @@ package prototype
 import (
 	"fmt"
 
+	"github.com/ksonnet/ksonnet/pkg/util/strings"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 )
 
@@ -35,6 +38,7 @@ func (e *FlagDefinitionError) Error() string {
 func BindFlags(p *Prototype) (fs *pflag.FlagSet, err error) {
 	fs = pflag.NewFlagSet("prototype-flags", pflag.ContinueOnError)
 
+	fs.String("values-file", "", "Prototype values file (file returns a Jsonnet object)")
 	fs.String("module", "", "Component module")
 
 	for _, param := range p.RequiredParams() {
@@ -52,4 +56,105 @@ func BindFlags(p *Prototype) (fs *pflag.FlagSet, err error) {
 	}
 
 	return fs, nil
+}
+
+// ExtractParameters extracts prototypes parameters from flags.
+func ExtractParameters(fs afero.Fs, p *Prototype, flags *pflag.FlagSet) (map[string]string, error) {
+
+	required := make(map[string]*ParamSchema)
+
+	values := map[string]string{}
+	for _, param := range p.Params {
+		if err := updateValuesFromFlag(p, values, param, flags); err != nil {
+			return nil, errors.Wrap(err, "reading value from flag")
+		}
+
+		if param.Default == nil {
+			required[param.Name] = param
+		}
+	}
+
+	valuesFilePath, err := flags.GetString("values-file")
+	if err != nil {
+		return nil, errors.Wrap(err, "finding values file flag")
+	}
+
+	if valuesFilePath != "" {
+		updateValuesFromValuesFile(fs, values, valuesFilePath)
+	}
+
+	if err = checkMissingParameters(p, values, required); err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+// updateValuesFromFlag updates values from flags. It mutates the map which is passed in.
+func updateValuesFromFlag(p *Prototype, values map[string]string, param *ParamSchema, flags *pflag.FlagSet) error {
+	val, err := flags.GetString(param.Name)
+	if err != nil {
+		return err
+	} else if _, ok := values[param.Name]; ok {
+		return errors.Errorf("prototype %q has multiple parameters with name %q", p.Name, param.Name)
+	}
+
+	quoted, err := param.Quote(val)
+	if err != nil {
+		return err
+	}
+	values[param.Name] = quoted
+
+	return nil
+}
+
+// updateValuesFromValuesFile updates values from a values file. It mutates the map which is passed in.
+func updateValuesFromValuesFile(fs afero.Fs, values map[string]string, valuesFilePath string) error {
+	f, err := fs.Open(valuesFilePath)
+	if err != nil {
+		return errors.Wrap(err, "opening values file")
+	}
+
+	defer f.Close()
+
+	vf, err := ReadValues(f)
+	if err != nil {
+		return errors.Wrap(err, "reading values file")
+	}
+
+	keys, err := vf.Keys()
+	if err != nil {
+		return errors.Wrap(err, "finding keys in values file")
+	}
+
+	for _, k := range keys {
+		v, err := vf.Get(k)
+		if err != nil {
+			return errors.Wrapf(err, "retrieving %q from values file", k)
+		}
+		values[k] = v
+	}
+
+	return nil
+}
+
+func checkMissingParameters(p *Prototype, values map[string]string, required map[string]*ParamSchema) error {
+	missingRequired := ParamSchemas{}
+
+	var keys []string
+	for k := range values {
+		keys = append(keys, k)
+	}
+
+	for k, v := range required {
+		if strings.InSlice(k, keys) && values[k] == `""` {
+			missingRequired = append(missingRequired, v)
+		}
+	}
+
+	if len(missingRequired) > 0 {
+		return errors.Errorf("failed to instantiate prototype %q. The following required parameters are missing:\n%s", p.Name, missingRequired.PrettyString(""))
+	}
+
+	return nil
 }

--- a/pkg/prototype/values_file.go
+++ b/pkg/prototype/values_file.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package prototype
+
+import (
+	"io"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	"github.com/ksonnet/ksonnet/pkg/util/jsonnet"
+	"github.com/pkg/errors"
+)
+
+// ValuesFile represents a prototype values file.
+type ValuesFile struct {
+	src string
+}
+
+// NewValuesFile creates an instance of ValuesFile.
+func NewValuesFile(src string) *ValuesFile {
+	return &ValuesFile{
+		src: src,
+	}
+}
+
+// Keys returns the keys in the values file.
+func (vf *ValuesFile) Keys() ([]string, error) {
+	obj, err := jsonnet.Parse("values-file", vf.src)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing values-file")
+	}
+
+	var keys []string
+
+	for i := range obj.Fields {
+		f := obj.Fields[i]
+
+		id, err := jsonnet.FieldID(f)
+		if err != nil {
+			return nil, errors.Wrap(err, "finding field in jsonnet object")
+		}
+
+		keys = append(keys, id)
+	}
+
+	sort.Strings(keys)
+
+	return keys, nil
+}
+
+// Get gets a value from the values file by key.
+func (vf *ValuesFile) Get(k string) (string, error) {
+	vm := jsonnet.NewVM()
+	vm.TLACode("object", vf.src)
+	vm.TLAVar("key", k)
+
+	v, err := vm.EvaluateSnippet("getValue", snippetFieldValue)
+	if err != nil {
+		return "", errors.Errorf("key %q was not found", k)
+	}
+
+	return strings.TrimSpace(v), nil
+}
+
+var snippetFieldValue = `
+function(object, key)
+	object[key]
+`
+
+// ReadValues reads a values file from a reader.
+func ReadValues(r io.Reader) (*ValuesFile, error) {
+	if r == nil {
+		return nil, errors.Errorf("reader is nil")
+	}
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading values")
+	}
+
+	vm := jsonnet.NewVM()
+
+	evaluated, err := vm.EvaluateSnippet("prototype-values", string(data))
+	if err != nil {
+		return nil, errors.Wrap(err, "evaluating values with jsonnet")
+	}
+
+	return &ValuesFile{
+		src: evaluated,
+	}, nil
+}

--- a/pkg/prototype/values_file_test.go
+++ b/pkg/prototype/values_file_test.go
@@ -1,0 +1,167 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package prototype
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuesFile_Keys(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		expected []string
+		isErr    bool
+	}{
+		{
+			name:     "valid",
+			src:      validValuesFile,
+			expected: []string{"arr", "name", "num", "obj"},
+		},
+		{
+			name:  "invalid",
+			src:   invalidValuesFile,
+			isErr: true,
+		},
+		{
+			name:  "invalid field id",
+			src:   invalidKeyValuesFile,
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vf := NewValuesFile(tc.src)
+			got, err := vf.Keys()
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestValuesFile_Get(t *testing.T) {
+	cases := []struct {
+		name     string
+		key      string
+		expected string
+		isErr    bool
+	}{
+		{
+			name:     "retrieve string",
+			key:      "name",
+			expected: `"name"`,
+		},
+		{
+			name:     "retrieve object",
+			key:      "obj",
+			expected: "{\n   \"k\": \"v\"\n}",
+		},
+		{
+			name:     "retrieve number",
+			key:      "num",
+			expected: `9`,
+		},
+		{
+			name:     "retrieve array",
+			key:      "arr",
+			expected: "[\n   1,\n   2,\n   3\n]",
+		},
+		{
+			name:  "invalid key",
+			key:   "invalid",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vf := NewValuesFile(validValuesFile)
+			got, err := vf.Get(tc.key)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestReadValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		r     io.Reader
+		isErr bool
+	}{
+		{
+			name: "valid jsonnet",
+			r:    strings.NewReader(validValuesFile),
+		},
+		{
+			name:  "blank jsonnet",
+			r:     strings.NewReader(""),
+			isErr: true,
+		},
+		{
+			name:  "nil reader",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vf, err := ReadValues(tc.r)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, vf.src)
+		})
+	}
+}
+
+var validValuesFile = `
+{
+	name: "name",
+	obj: {k: "v"},
+	num: 9,
+	arr: [1,2,3],
+}
+`
+
+var invalidValuesFile = `
+{`
+
+var invalidKeyValuesFile = `
+{
+	[x]: "name",
+}`


### PR DESCRIPTION
This change introduces a values file to be used when setting prototype
values for the use and preview commands.

The format of the file is Jsonnet that returns an object.

Notes:

* if values are added to the file and aren't consumed by prototype, they are ignored.

Fixes #550 

Signed-off-by: bryanl <bryanliles@gmail.com>