### PR TITLE
When listing packages, include version

### DIFF
--- a/pkg/actions/pkg_list.go
+++ b/pkg/actions/pkg_list.go
@@ -89,14 +89,14 @@ func (pl *PkgList) Run() error {
 			return err
 		}
 
-		for libName := range spec.Libraries {
+		for libName, config := range spec.Libraries {
 			_, isInstalled := appLibraries[libName]
 
 			if pl.onlyInstalled && !isInstalled {
 				continue
 			}
 
-			rows = append(rows, pl.addRow(r.Name(), libName, isInstalled))
+			rows = append(rows, pl.addRow(r.Name(), libName, config.Version, isInstalled))
 		}
 	}
 
@@ -108,13 +108,13 @@ func (pl *PkgList) Run() error {
 	})
 
 	t := table.New(pl.out)
-	t.SetHeader([]string{"registry", "name", "installed"})
+	t.SetHeader([]string{"registry", "name", "version", "installed"})
 	t.AppendBulk(rows)
 	return t.Render()
 }
 
-func (pl *PkgList) addRow(regName, libName string, isInstalled bool) []string {
-	row := []string{regName, libName}
+func (pl *PkgList) addRow(regName, libName, version string, isInstalled bool) []string {
+	row := []string{regName, libName, version}
 	if isInstalled {
 		row = append(row, pkgInstalled)
 	}

--- a/pkg/actions/pkg_list_test.go
+++ b/pkg/actions/pkg_list_test.go
@@ -35,8 +35,8 @@ func TestPkgList(t *testing.T) {
 
 		spec := &registry.Spec{
 			Libraries: registry.LibraryConfigs{
-				"lib1": &registry.LibaryConfig{},
-				"lib2": &registry.LibaryConfig{},
+				"lib1": &registry.LibaryConfig{Version: "0.0.1"},
+				"lib2": &registry.LibaryConfig{Version: "master"},
 			},
 		}
 

--- a/pkg/actions/testdata/pkg/list/installed.txt
+++ b/pkg/actions/testdata/pkg/list/installed.txt
@@ -1,3 +1,3 @@
-REGISTRY  NAME INSTALLED
-========  ==== =========
-incubator lib1 *
+REGISTRY  NAME VERSION INSTALLED
+========  ==== ======= =========
+incubator lib1 0.0.1   *

--- a/pkg/actions/testdata/pkg/list/output.txt
+++ b/pkg/actions/testdata/pkg/list/output.txt
@@ -1,4 +1,4 @@
-REGISTRY  NAME INSTALLED
-========  ==== =========
-incubator lib1 *
-incubator lib2
+REGISTRY  NAME VERSION INSTALLED
+========  ==== ======= =========
+incubator lib1 0.0.1   *
+incubator lib2 master


### PR DESCRIPTION
```
➜  ksapp2 ks pkg list
REGISTRY  NAME      VERSION INSTALLED
========  ====      ======= =========
incubator apache    master
incubator efk       master
incubator mariadb   master
incubator memcached master
incubator mongodb   master
incubator mysql     master
incubator nginx     master
incubator node      master
incubator postgres  master
incubator redis     master
incubator tomcat    master
```

And after installing a package:

```
➜  ksapp2 ks pkg list --installed
REGISTRY  NAME   VERSION INSTALLED
========  ====   ======= =========
incubator apache master  *
```

#626

Signed-off-by: bryanl <bryanliles@gmail.com>