### PR TITLE
ks upgrade relocates vendored packages to versioned paths

### DIFF
--- a/pkg/actions/upgrade_test.go
+++ b/pkg/actions/upgrade_test.go
@@ -16,26 +16,34 @@
 package actions
 
 import (
+	"io"
 	"testing"
 
+	"github.com/ksonnet/ksonnet/pkg/app"
 	amocks "github.com/ksonnet/ksonnet/pkg/app/mocks"
+	"github.com/ksonnet/ksonnet/pkg/upgrade"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUpgrade(t *testing.T) {
 	withApp(t, func(appMock *amocks.App) {
-		appMock.On("Upgrade", true).Return(nil)
-
 		in := map[string]interface{}{
 			OptionApp:    appMock,
 			OptionDryRun: true,
 		}
 
-		a, err := newUpgrade(in)
+		var called bool
+		u, err := newUpgrade(in)
+		u.upgradeFn = func(a app.App, out io.Writer, pl upgrade.PackageLister, dryRun bool) error {
+			called = true
+			return nil
+		}
+
 		require.NoError(t, err)
 
-		err = a.run()
+		err = u.run()
 		require.NoError(t, err)
+		require.True(t, called)
 	})
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -70,8 +70,8 @@ type App interface {
 	EnvironmentParams(name string) (string, error)
 	// Fs is the app's afero Fs.
 	Fs() afero.Fs
-	// Init inits an environment.
-	Init() error
+	// CheckUpgrade checks whether an app should be upgraded.
+	CheckUpgrade() (bool, error)
 	// LibPath returns the path of the lib for an environment.
 	LibPath(envName string) (string, error)
 	// Libraries returns all environments.
@@ -111,8 +111,6 @@ func Load(fs afero.Fs, cwd string, skipFindRoot bool) (App, error) {
 		}
 	}
 
-	log.Debugf("called")
-
 	spec, err := read(fs, appRoot)
 	if os.IsNotExist(err) {
 		// During `ks init`, app.yaml will not yet exist - generate a new one.
@@ -133,7 +131,7 @@ func Load(fs afero.Fs, cwd string, skipFindRoot bool) (App, error) {
 		// 0.2.0, but will be persisted back as 0.2.0. This behavior will be
 		// subsequently changed with new upgrade framework.
 		a := NewApp010(fs, appRoot)
-		log.Debugf("Upgrading app [%p] version to latest (0.2.0)", a.baseApp)
+		log.Debugf("Interpreting app version as latest (0.2.0)", a.baseApp)
 		a.config.APIVersion = "0.2.0"
 		a.baseApp.config.APIVersion = "0.2.0"
 		return a, nil

--- a/pkg/app/app001.go
+++ b/pkg/app/app001.go
@@ -120,13 +120,13 @@ func (a *App001) Environments() (EnvironmentConfigs, error) {
 	return specs, nil
 }
 
-// Init initializes the App.
-func (a *App001) Init() error {
+// CheckUpgrade initializes the App.
+func (a *App001) CheckUpgrade() (bool, error) {
 	msg := "Your application's apiVersion is below 0.1.0. In order to use all ks features, you " +
 		"can upgrade your application using `ks upgrade`."
 	log.Warn(msg)
 
-	return nil
+	return true, nil
 }
 
 // LibPath returns the lib path for an env environment.

--- a/pkg/app/app001_test.go
+++ b/pkg/app/app001_test.go
@@ -237,10 +237,11 @@ func TestApp001_RemoveEnvironment(t *testing.T) {
 	})
 }
 
-func TestApp001_Init(t *testing.T) {
+func TestApp001_CheckUpgrade(t *testing.T) {
 	withApp001Fs(t, "app001_app.yaml", func(app *App001) {
-		err := app.Init()
+		needUpgrade, err := app.CheckUpgrade()
 		require.NoError(t, err)
+		assert.True(t, needUpgrade)
 	})
 }
 

--- a/pkg/app/mocks/App.go
+++ b/pkg/app/mocks/App.go
@@ -53,6 +53,27 @@ func (_m *App) AddRegistry(spec *app.RegistryConfig, isOverride bool) error {
 	return r0
 }
 
+// CheckUpgrade provides a mock function with given fields:
+func (_m *App) CheckUpgrade() (bool, error) {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CurrentEnvironment provides a mock function with given fields:
 func (_m *App) CurrentEnvironment() string {
 	ret := _m.Called()
@@ -145,20 +166,6 @@ func (_m *App) Fs() afero.Fs {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(afero.Fs)
 		}
-	}
-
-	return r0
-}
-
-// Init provides a mock function with given fields:
-func (_m *App) Init() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/pkg/pkg/local.go
+++ b/pkg/pkg/local.go
@@ -64,8 +64,7 @@ func NewLocal(a app.App, name, registryName string, version string, installCheck
 		// Fallback succeeded - clear out original error to allow processing to continue
 		err = nil
 
-		// Alert the user that the application should be upgraded
-		log.Warnf("Versioned package %s/%s@%s stored in unversioned path - please run `ks upgrade` to correct.", registryName, name, version)
+		log.Debugf("Using legacy path for versioned package %s/%s@%s", registryName, name, version)
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading package configuration from path: %v", partsPath)

--- a/pkg/upgrade/testdata/app010_app.yaml
+++ b/pkg/upgrade/testdata/app010_app.yaml
@@ -1,0 +1,33 @@
+apiVersion: 0.1.0
+environments:
+  default:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: default
+  us-east/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-east/test
+  us-west/prod:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/prod
+  us-west/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/test
+kind: ksonnet.io/app
+name: test-get-envs
+registries:
+  incubator:
+    protocol: ""
+    uri: ""
+version: 0.0.1

--- a/pkg/upgrade/testdata/main.jsonnet
+++ b/pkg/upgrade/testdata/main.jsonnet
@@ -1,0 +1,7 @@
+local base = import "../base.libsonnet";
+local k = import "k.libsonnet";
+
+base + {
+  // Insert user-specified overrides here. For example if a component is named "nginx-deployment", you might have something like:
+  //   "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
+}

--- a/pkg/upgrade/testdata/packages/mysql/parts.yaml
+++ b/pkg/upgrade/testdata/packages/mysql/parts.yaml
@@ -1,0 +1,40 @@
+{
+  "name": "mysql",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
+  "description": "MySQL is one of the most popular database servers in the world. Notable users include Wikipedia, Facebook and Google.",
+  "author": "ksonnet team <ksonnet-help@heptio.com>",
+  "contributors": [
+    {
+    "name": "Tehut Getahun",
+    "email": "tehut@heptio.com"
+    },
+    {
+    "name": "Tamiko Terada",
+    "email": "tamiko@heptio.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksonnet/mixins"
+  },
+  "bugs": {
+    "url": "https://github.com/ksonnet/mixins/issues"
+  },
+  "keywords": [
+    "mysql",
+    "database",
+    "relational"
+  ],
+  "quickStart": {
+    "prototype": "io.ksonnet.pkg.simple-mysql",
+    "componentName": "mysql",
+    "flags": {
+      "name": "mysql",
+      "namespace": "default"
+    },
+    "comment": "Run a simple MySQL server"
+  },
+  "license": "Apache 2.0"
+}
+

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package upgrade
+
+import (
+	"io"
+
+	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/pkg/errors"
+)
+
+// Upgrade upgrades an application to the current version.
+func Upgrade(a app.App, out io.Writer, pl PackageLister, dryRun bool) error {
+	// TODO new migration framework goes here
+
+	if a == nil {
+		return errors.Errorf("nil receiver")
+	}
+
+	switch va := a.(type) {
+	default:
+		return errors.Errorf("Unknown app type: %T", a)
+	case *app.App001:
+		// First we upgrade 0.0.1 -> 0.1.0, then 0.1.0 -> 0.2.0
+		u := newUpgrade001(va)
+		err := u.Upgrade(dryRun)
+		if err != nil {
+			return errors.Wrapf(err, "upgrading from 0.0.1 to 0.1.0")
+		}
+
+		// Reload App between upgrades
+		app010, err := app.Load(va.Fs(), va.Root(), false)
+		if err != nil {
+			return errors.Wrapf(err, "reloading app after 0.1.0 upgrade")
+		}
+
+		u2 := newUpgrade010(app010, out, pl)
+		err = u2.Upgrade(dryRun)
+		if err != nil {
+			return errors.Wrapf(err, "upgrading from 0.1.0 to 0.2.0")
+		}
+
+		return nil
+	case *app.App010:
+		u := newUpgrade010(va, out, pl)
+		err := u.Upgrade(dryRun)
+		if err != nil {
+			return errors.Wrapf(err, "upgrading from 0.1.0 to 0.2.0")
+		}
+		return nil
+	}
+}

--- a/pkg/upgrade/upgrade001.go
+++ b/pkg/upgrade/upgrade001.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package upgrade
+
+import (
+	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/pkg/errors"
+)
+
+type upgrade001 struct {
+	app app.App
+}
+
+// newUpgrade001 constructs an Upgrader from version 0.0.1->0.1.0
+func newUpgrade001(a app.App) *upgrade001 {
+	return &upgrade001{
+		app: a,
+	}
+}
+
+// Upgrade upgrades the app to the latest apiVersion.
+func (u *upgrade001) Upgrade(dryRun bool) error {
+	if u == nil {
+		return errors.Errorf("nil receiver")
+	}
+	if u.app == nil {
+		return errors.Errorf("nil app")
+	}
+	return u.app.Upgrade(dryRun)
+}

--- a/pkg/upgrade/upgrade010.go
+++ b/pkg/upgrade/upgrade010.go
@@ -1,0 +1,183 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package upgrade
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+
+	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/lib"
+	"github.com/ksonnet/ksonnet/pkg/pkg"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+// PackageLister lists installed packages.
+type PackageLister interface {
+	Packages() ([]pkg.Package, error)
+}
+
+type upgrade010 struct {
+	out           io.Writer
+	app           app.App
+	packageLister PackageLister
+}
+
+// NewUpgrade010 constructs an Upgrader from version 0.1.0->0.2.0
+func newUpgrade010(a app.App, out io.Writer, pl PackageLister) *upgrade010 {
+	return &upgrade010{
+		app:           a,
+		out:           out,
+		packageLister: pl,
+	}
+}
+
+// Upgrade upgrades the app to the latest apiVersion.
+func (u *upgrade010) Upgrade(dryRun bool) error {
+	if err := u.checkForOldKSLibLocation(dryRun); err != nil {
+		return errors.Wrapf(err, "upgrading kslib location")
+	}
+
+	if u.packageLister == nil {
+		return errors.Errorf("nil packageLister")
+	}
+	if err := u.upgradeOldVendoredPackages(u.packageLister, dryRun); err != nil {
+		return errors.Wrapf(err, "upgrading vendored packages")
+	}
+
+	// Upgrade app.yaml
+	return u.app.Upgrade(dryRun)
+}
+
+var (
+	// reKSLibName matches a ksonnet library directory e.g. v1.10.3.
+	reKSLibName = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+)
+
+func (u *upgrade010) checkForOldKSLibLocation(dryRun bool) error {
+	fs := u.app.Fs()
+	libRoot := filepath.Join(u.app.Root(), app.LibDirName)
+	fis, err := afero.ReadDir(fs, libRoot)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Fprintf(u.out, "[dry run] Updating ksonnet-lib paths\n")
+	} else {
+		if err = fs.MkdirAll(filepath.Join(libRoot, lib.KsonnetLibHome), app.DefaultFolderPermissions); err != nil {
+			return err
+		}
+	}
+
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			continue
+		}
+
+		if reKSLibName.MatchString(fi.Name()) {
+			p := filepath.Join(libRoot, fi.Name())
+			new := filepath.Join(libRoot, lib.KsonnetLibHome, fi.Name())
+
+			if dryRun {
+				fmt.Fprintf(u.out, "[dry run] Moving %q from %s to %s\n", fi.Name(), p, new)
+				continue
+			}
+
+			fmt.Fprintf(u.out, "Moving %q from %s to %s\n", fi.Name(), p, new)
+			err = fs.Rename(p, new)
+			if err != nil {
+				return errors.Wrapf(err, "renaming %s to %s", p, new)
+			}
+		}
+	}
+
+	return nil
+}
+
+var removeVersionPattern = regexp.MustCompile("(.*)@.*$")
+
+// In ksonnet 0.12.0 (app version 0.2.0) - the vendor cache began storing
+// packages using versioned paths. This upgrade translates old paths into new, versioned paths.
+// Example:
+// `vendor/incubator/mysql` -> `vendor/incubator/mysql@1.2.3`
+func (u *upgrade010) upgradeOldVendoredPackages(pl PackageLister, dryRun bool) error {
+	if u == nil {
+		return errors.Errorf("nil receiver")
+	}
+	if u.app == nil {
+		return errors.Errorf("nil app")
+	}
+	fs := u.app.Fs()
+	if fs == nil {
+		return errors.Errorf("nil filesystem interface")
+	}
+	if pl == nil {
+		return errors.Errorf("nil packageLister")
+	}
+
+	if dryRun {
+		fmt.Fprintf(u.out, "[dry run] Updating vendored packages\n")
+	}
+
+	pkgs, err := pl.Packages()
+	if err != nil {
+		return errors.Wrapf(err, "resolving packages")
+	}
+
+	for _, p := range pkgs {
+		if p.Version() == "" {
+			// Skip unversioned packages
+			continue
+		}
+
+		versioned := p.Path()
+
+		ok, err := afero.Exists(fs, versioned)
+		if err != nil {
+			return errors.Wrapf(err, "checking package: %v", p)
+		}
+		if ok {
+			// Already upgraded
+			continue
+		}
+
+		// Check for unversioned path
+		unversioned := string(removeVersionPattern.ReplaceAll([]byte(versioned), []byte("$1")))
+		ok, err = afero.Exists(fs, unversioned)
+		if err != nil {
+			return errors.Wrapf(err, "checking path: %v", unversioned)
+		}
+		if !ok {
+			// Nothing to upgrade, the package is simply missing
+			continue
+		}
+
+		// Ok, time to upgrade -> unversioned -> versioned
+		if dryRun {
+			fmt.Fprintf(u.out, "[dry run] Moving %q from %s to %s\n", p, unversioned, versioned)
+			continue
+		}
+		if err := fs.Rename(unversioned, versioned); err != nil {
+			return errors.Wrapf(err, "renaming %v to %v", unversioned, versioned)
+		}
+	}
+
+	return nil
+}

--- a/pkg/upgrade/upgrade010_test.go
+++ b/pkg/upgrade/upgrade010_test.go
@@ -1,0 +1,215 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package upgrade
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/pkg"
+	pmocks "github.com/ksonnet/ksonnet/pkg/pkg/mocks"
+	rmocks "github.com/ksonnet/ksonnet/pkg/registry/mocks"
+	"github.com/ksonnet/ksonnet/pkg/util/test"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var LibUpdater = app.LibUpdater
+
+type upgrader interface {
+	Upgrade(dryRun bool) error
+}
+
+func withApp010Fs(t *testing.T, appName string, fn func(app *app.App010)) {
+	ogLibUpdater := LibUpdater
+	LibUpdater = func(fs afero.Fs, k8sSpecFlag string, libPath string) (string, error) {
+		return "v1.8.7", nil
+	}
+
+	defer func() {
+		LibUpdater = ogLibUpdater
+	}()
+
+	fs := afero.NewMemMapFs()
+
+	envDirs := []string{
+		"default",
+		"us-east/test",
+		"us-west/test",
+		"us-west/prod",
+	}
+
+	for _, dir := range envDirs {
+		path := filepath.Join("/environments", dir)
+		err := fs.MkdirAll(path, app.DefaultFolderPermissions)
+		require.NoError(t, err)
+
+		swaggerPath := filepath.Join(path, "main.jsonnet")
+		test.StageFile(t, fs, "main.jsonnet", swaggerPath)
+	}
+
+	test.StageFile(t, fs, appName, "/app.yaml")
+
+	app := app.NewApp010(fs, "/")
+
+	fn(app)
+}
+
+func TestApp010_Upgrade(t *testing.T) {
+	var b bytes.Buffer
+	var defaultPM rmocks.PackageManager
+	defaultPM.On("Packages").Return([]pkg.Package{}, nil)
+
+	cases := []struct {
+		name         string
+		init         func(t *testing.T, a *app.App010) upgrader
+		checkUpgrade func(t *testing.T, a *app.App010)
+		dryRun       bool
+		isErr        bool
+	}{
+		{
+			name: "ksonnet lib doesn't need to be upgraded",
+			init: func(t *testing.T, a *app.App010) upgrader {
+				err := a.Fs().MkdirAll("/lib", app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(a.Root(), "lib", "ksonnet-lib", "v1.10.3")
+				err = a.Fs().MkdirAll(p, app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				return newUpgrade010(a, &b, &defaultPM)
+			},
+			dryRun: false,
+		},
+		{
+			name: "ksonnet lib needs to be upgraded",
+			init: func(t *testing.T, a *app.App010) upgrader {
+				err := a.Fs().MkdirAll("/lib", app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(a.Root(), "lib", "v1.10.3")
+				err = a.Fs().MkdirAll(p, app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				return newUpgrade010(a, &b, &defaultPM)
+			},
+			dryRun: false,
+		},
+		{
+			name: "ksonnet lib needs to be upgraded - dry run",
+			init: func(t *testing.T, a *app.App010) upgrader {
+				err := a.Fs().MkdirAll("/lib", app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				p := filepath.Join(a.Root(), "lib", "v1.10.3")
+				err = a.Fs().MkdirAll(p, app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				return newUpgrade010(a, &b, &defaultPM)
+			},
+			checkUpgrade: func(t *testing.T, a *app.App010) {
+				isDir, err := afero.IsDir(a.Fs(), filepath.Join("/lib", "v1.10.3"))
+				require.NoError(t, err)
+				require.True(t, isDir)
+			},
+			dryRun: true,
+		},
+		{
+			name:  "lib doesn't exist",
+			isErr: true,
+			init: func(t *testing.T, a *app.App010) upgrader {
+				return newUpgrade010(a, &b, &defaultPM)
+			},
+		},
+		{
+			name: "vendored packages need to be upgraded",
+			init: func(t *testing.T, a *app.App010) upgrader {
+				err := a.Fs().MkdirAll("/lib", app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				test.StageDir(t, a.Fs(), filepath.FromSlash("packages/mysql"), filepath.FromSlash("/vendor/incubator/mysql"))
+
+				var p pmocks.Package
+				var pm rmocks.PackageManager
+				p.On("Version").Return("1.2.3")
+				p.On("String").Return("incubator/mysql@1.2.3")
+				p.On("Path").Return("/vendor/incubator/mysql@1.2.3")
+				pm.On("Packages").Return(
+					[]pkg.Package{&p}, nil,
+				)
+				return newUpgrade010(a, &b, &pm)
+			},
+			checkUpgrade: func(t *testing.T, a *app.App010) {
+				ok, err := afero.DirExists(a.Fs(), "/vendor/incubator/mysql@1.2.3")
+				require.NoError(t, err)
+				assert.True(t, ok, "checking for upgraded package path")
+			},
+			dryRun: false,
+		},
+		{
+			name: "unversion packages are untouched",
+			init: func(t *testing.T, a *app.App010) upgrader {
+				err := a.Fs().MkdirAll("/lib", app.DefaultFolderPermissions)
+				require.NoError(t, err)
+
+				test.StageDir(t, a.Fs(), filepath.FromSlash("packages/mysql"), filepath.FromSlash("/vendor/incubator/mysql"))
+
+				var p pmocks.Package
+				var pm rmocks.PackageManager
+				p.On("Version").Return("")
+				pm.On("Packages").Return(
+					[]pkg.Package{&p}, nil,
+				)
+				return newUpgrade010(a, &b, &pm)
+			},
+			checkUpgrade: func(t *testing.T, a *app.App010) {
+				ok, err := afero.DirExists(a.Fs(), "/vendor/incubator/mysql")
+				require.NoError(t, err)
+				assert.True(t, ok, "checking for upgraded package path")
+			},
+			dryRun: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withApp010Fs(t, "app010_app.yaml", func(a *app.App010) {
+				var u upgrader
+				if tc.init != nil {
+					u = tc.init(t, a)
+				} else {
+					u = newUpgrade010(a, &b, &defaultPM)
+				}
+
+				err := u.Upgrade(tc.dryRun)
+				if tc.isErr {
+					require.Error(t, err, tc.name)
+					return
+				}
+
+				require.NoError(t, err, tc.name)
+
+				if tc.checkUpgrade != nil {
+					tc.checkUpgrade(t, a)
+				}
+				b.Reset()
+			})
+		})
+	}
+}


### PR DESCRIPTION
Example:
`vendor/<registry>/<pkg>` -> `vendor/<registry>/<pkg>@<version>`

Closes #663

Signed-off-by: Oren Shomron <shomron@gmail.com>