### PR TITLE
Create module when child exists

### DIFF
--- a/pkg/actions/module_create.go
+++ b/pkg/actions/module_create.go
@@ -56,7 +56,7 @@ func NewModuleCreate(m map[string]interface{}) (*ModuleCreate, error) {
 	return mc, nil
 }
 
-// Run runs that ns create action.
+// Run runs the module create action.
 func (mc *ModuleCreate) Run() error {
 	_, err := mc.cm.Module(mc.app, mc.module)
 	if err == nil {

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -63,7 +63,7 @@ var (
 	DefaultManager = &defaultManager{}
 )
 
-// Manager is an interface for interating with components.
+// Manager is an interface for interacting with components.
 type Manager interface {
 	Components(ns Module) ([]Component, error)
 	Component(ksApp app.App, module, componentName string) (Component, error)

--- a/pkg/component/module.go
+++ b/pkg/component/module.go
@@ -146,11 +146,7 @@ func GetModule(a app.App, moduleName string) (Module, error) {
 	parts := strings.Split(moduleName, ".")
 	moduleDir := filepath.Join(append([]string{a.Root(), componentsRoot}, parts...)...)
 
-	exists, err := afero.Exists(a.Fs(), moduleDir)
-	if err != nil {
-		return nil, err
-	}
-
+	exists, _ := afero.Exists(a.Fs(), filepath.Join(moduleDir, paramsFile))
 	if !exists {
 		return nil, errors.New(moduleErrorMsg("unable to find %s", moduleName))
 	}
@@ -238,7 +234,7 @@ func (mp *ModuleParameter) IsSameType(other ModuleParameter) bool {
 		mp.Key == other.Key
 }
 
-// ResolvedParams resolves paramaters for a module. It returns a JSON encoded
+// ResolvedParams resolves parameters for a module. It returns a JSON encoded
 // string of component parameters.
 func (m *FilesystemModule) ResolvedParams(envName string) (string, error) {
 	s, err := m.readParams()

--- a/pkg/component/module_test.go
+++ b/pkg/component/module_test.go
@@ -16,8 +16,10 @@
 package component
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/ksonnet/ksonnet/pkg/app"
 	"github.com/ksonnet/ksonnet/pkg/app/mocks"
 	"github.com/ksonnet/ksonnet/pkg/util/test"
 	"github.com/spf13/afero"
@@ -74,6 +76,7 @@ func Test_GetModule(t *testing.T) {
 			test.WithApp(t, "/app", func(a *mocks.App, fs afero.Fs) {
 				if tc.dir != "" {
 					err := fs.MkdirAll(tc.dir, 0755)
+					afero.WriteFile(fs, filepath.Join(tc.dir, paramsFile), []byte("{}"), app.DefaultFolderPermissions)
 					require.NoError(t, err)
 				}
 
@@ -93,8 +96,8 @@ func Test_GetModule(t *testing.T) {
 
 func TestModule_Components(t *testing.T) {
 	test.WithApp(t, "/app", func(a *mocks.App, fs afero.Fs) {
-		test.StageFile(t, fs, "certificate-crd.yaml", "/app/components/ns1/certificate-crd.yaml")
-		test.StageFile(t, fs, "params-with-entry.libsonnet", "/app/components/ns1/params.libsonnet")
+		test.StageFile(t, fs, "certificate-crd.yaml", "/app/components/module1/certificate-crd.yaml")
+		test.StageFile(t, fs, "params-with-entry.libsonnet", "/app/components/module1/params.libsonnet")
 		test.StageFile(t, fs, "params-no-entry.libsonnet", "/app/components/params.libsonnet")
 
 		cases := []struct {
@@ -108,7 +111,7 @@ func TestModule_Components(t *testing.T) {
 			},
 			{
 				name:   "with components",
-				module: "ns1",
+				module: "module1",
 				count:  1,
 			},
 		}


### PR DESCRIPTION
Allow creation of module `a` when module `a.b` previously exists.
Changes module finding to look for `params.libsonnet` instead of
the module directory.

Fixes #675

Signed-off-by: bryanl <bryanliles@gmail.com>