### PR TITLE
Add environment directory to jsonnet path before eval

### DIFF
--- a/pkg/params/evaluate.go
+++ b/pkg/params/evaluate.go
@@ -36,7 +36,9 @@ func EvaluateEnv(a app.App, sourcePath, paramsStr, envName, moduleName string) (
 		return "", errors.Wrap(err, "modularizing parameters")
 	}
 
-	moduleParams, err := BuildEnvParamsForModule(moduleName, string(snippet), paramsStr)
+	envDir := filepath.Dir(sourcePath)
+
+	moduleParams, err := BuildEnvParamsForModule(moduleName, string(snippet), paramsStr, envDir)
 	if err != nil {
 		return "", errors.Wrapf(err, "selecting params for module %q in environment %q", moduleName, envName)
 	}

--- a/pkg/params/for.go
+++ b/pkg/params/for.go
@@ -39,7 +39,7 @@ import (
 // 	},
 //   }
 // ```
-func BuildEnvParamsForModule(moduleName, paramsStr, componentParams string) (string, error) {
+func BuildEnvParamsForModule(moduleName, paramsStr, componentParams, envDir string) (string, error) {
 	script, err := loadScript("params_for_module.libsonnet")
 	if err != nil {
 		return "", errors.Wrap(err, "loading script")
@@ -49,6 +49,7 @@ func BuildEnvParamsForModule(moduleName, paramsStr, componentParams string) (str
 	vm.TLAVar("moduleName", moduleName)
 	vm.TLACode("input", paramsStr)
 	vm.ExtCode("__ksonnet/params", componentParams)
+	vm.AddJPath(envDir)
 
 	output, err := vm.EvaluateSnippet("params-for-module", script)
 	if err != nil {

--- a/pkg/params/for_test.go
+++ b/pkg/params/for_test.go
@@ -61,7 +61,7 @@ func TestBuildEnvParamsForModule(t *testing.T) {
 			paramsStr := test.ReadTestData(t, filepath.Join("build_env_params", tc.input))
 			componentParams := test.ReadTestData(t, filepath.Join("build_env_params", tc.componentParams))
 
-			got, err := BuildEnvParamsForModule(tc.moduleName, paramsStr, componentParams)
+			got, err := BuildEnvParamsForModule(tc.moduleName, paramsStr, componentParams, ".")
 			require.NoError(t, err)
 
 			expected := test.ReadTestData(t, filepath.Join("build_env_params", tc.output))


### PR DESCRIPTION
Solves issue with not being able to find `globals.libsonnet` by adding the environment directory to the jsonnet path.

Signed-off-by: bryanl <bryanliles@gmail.com>