### PR TITLE
Helm chart verification

### DIFF
--- a/hacks/ks-verify-helm.rb
+++ b/hacks/ks-verify-helm.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+
+# verify charts specified in a helm repository render with ks
+# usage: ks-verify-helm.rb [helm repo URL]
+
+require 'net/http'
+require 'open3'
+require 'timeout'
+require 'tmpdir'
+require 'uri'
+require 'yaml'
+
+DEFAULT_HELM_REPO_URL="https://kubernetes-charts.storage.googleapis.com/index.yaml"
+
+helm_repo_url = ARGV[0] || DEFAULT_HELM_REPO_URL
+
+tmp_dir = Dir.mktmpdir("ks-verify-helm-", "/tmp")
+at_exit { FileUtils.remove_entry(tmp_dir) }
+
+app_name = (0...6).map { (65 + rand(26)).chr }.join
+
+# generate a ksonnet app
+Dir.chdir(tmp_dir) do
+    `ks init #{app_name} --skip-default-registries > /dev/null 2>&1`
+end
+
+fails = []
+
+Dir.chdir("#{tmp_dir}/#{app_name}") do
+    uri = URI.parse(helm_repo_url)
+    response = Net::HTTP.get(uri)
+
+    `ks registry add helm #{helm_repo_url}`
+
+    repo = YAML.load(response)
+    repo["entries"].each_with_index do |(key,_), index|
+        puts "checking #{index+1}: #{key}"
+        `ks pkg install helm/#{key} > /dev/null 2>&1`
+        `ks module create #{key} > /dev/null 2>&1`
+        `ks env add #{key} > /dev/null 2>&1`
+        `ks env targets #{key} --module #{key} > /dev/null 2>&1`
+
+        Open3.popen3("ks generate helm-#{key} #{key}.#{key}") do |_, _, stderr, thr|
+            if thr.value != 0
+                puts "generating #{key} failure:"
+                puts stderr.read
+                fails << key
+                next
+            end
+        end
+
+        begin
+            Timeout::timeout(15) do
+                Open3.popen3("ks show #{key}") do |_, _, stderr, thr|
+                    if thr.value != 0
+                        puts "#{key} failed"
+                        puts stderr.read
+                        fails << key
+                    end
+                end
+            end
+        rescue => e
+            puts "timed out showing #{key}"
+        end
+    end
+end
+
+unless fails.empty?
+    puts fails.inspect
+    exit(1)
+end
+
+

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -138,7 +138,7 @@ func evaluateMain(a app.App, envName, snippet, components, paramsStr string, opt
 		libPath,
 	)
 
-	helmRenderer := helm.NewRenderer(a)
+	helmRenderer := helm.NewRenderer(a, envName)
 	vm.AddFunctions(helmRenderer.JsonnetNativeFunc())
 
 	// Re-vendor versioned packages, such that import paths will remain path-agnostic.

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -17,9 +17,14 @@ package helm
 
 import (
 	"path/filepath"
+<<<<<<< HEAD
+	"strings"
+=======
+>>>>>>> 4417ebd4... update version sorting
 
 	"github.com/blang/semver"
 	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/util/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
@@ -33,24 +38,27 @@ func LatestChartVersion(a app.App, repoName, chartName string) (string, error) {
 		return "", errors.Wrapf(err, "reading dir %q", path)
 	}
 
-	var versions semver.Versions
+	var versions []version.Version
 
 	for _, fi := range fis {
 		if !fi.IsDir() {
 			continue
 		}
-		v, err := semver.Make(fi.Name())
+
+		v, err := version.Make(fi.Name())
 		if err != nil {
-			continue
+			return "", err
 		}
 
 		versions = append(versions, v)
+
 	}
 
 	if len(versions) == 0 {
 		return "", errors.Errorf("chart %s/%s doesn't have any releases", repoName, chartName)
 	}
 
-	semver.Sort(versions)
-	return versions[0].String(), nil
+	version.Sort(versions)
+	lastestVersion := versions[len(versions)-1]
+	return lastestVersion.String(), nil
 }

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -17,12 +17,7 @@ package helm
 
 import (
 	"path/filepath"
-<<<<<<< HEAD
-	"strings"
-=======
->>>>>>> 4417ebd4... update version sorting
 
-	"github.com/blang/semver"
 	"github.com/ksonnet/ksonnet/pkg/app"
 	"github.com/ksonnet/ksonnet/pkg/util/version"
 	"github.com/pkg/errors"
@@ -51,7 +46,6 @@ func LatestChartVersion(a app.App, repoName, chartName string) (string, error) {
 		}
 
 		versions = append(versions, v)
-
 	}
 
 	if len(versions) == 0 {

--- a/pkg/helm/renderer_test.go
+++ b/pkg/helm/renderer_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ksonnet/ksonnet/pkg/app"
 	amocks "github.com/ksonnet/ksonnet/pkg/app/mocks"
 	"github.com/ksonnet/ksonnet/pkg/util/jsonnet"
 	"github.com/ksonnet/ksonnet/pkg/util/test"
@@ -61,7 +62,12 @@ func TestRenderer_Render(t *testing.T) {
 			test.WithAppFs(t, tmpDir, fs, func(a *amocks.App, fs afero.Fs) {
 				test.StageDir(t, fs, "redis", filepath.Join(a.Root(), "vendor", "helm-stable", "redis"))
 
-				r := NewRenderer(a)
+				envConfig := &app.EnvironmentConfig{
+					KubernetesVersion: "v1.10.3",
+				}
+				a.On("Environment", "default").Return(envConfig, nil)
+
+				r := NewRenderer(a, "default")
 
 				values := map[string]interface{}{}
 
@@ -107,7 +113,12 @@ func TestRenderer_JsonnetNativeFunc(t *testing.T) {
 			test.WithAppFs(t, tmpDir, fs, func(a *amocks.App, fs afero.Fs) {
 				test.StageDir(t, fs, "redis", filepath.Join(a.Root(), "vendor", "helm-stable", "redis"))
 
-				r := NewRenderer(a)
+				envConfig := &app.EnvironmentConfig{
+					KubernetesVersion: "v1.10.3",
+				}
+				a.On("Environment", "default").Return(envConfig, nil)
+
+				r := NewRenderer(a, "default")
 
 				vm := jsonnet.NewVM()
 				vm.AddFunctions(r.JsonnetNativeFunc())

--- a/pkg/util/version/sort.go
+++ b/pkg/util/version/sort.go
@@ -1,0 +1,26 @@
+package version
+
+import "sort"
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].v.LT(s[j].v)
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/pkg/util/version/sort_test.go
+++ b/pkg/util/version/sort_test.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSort(t *testing.T) {
+	versionNames := []string{
+		"6.5.1",
+		"0.1.3",
+		"11.3",
+	}
+
+	var versions []Version
+
+	for _, s := range versionNames {
+		v, err := Make(s)
+		require.NoError(t, err)
+
+		versions = append(versions, v)
+	}
+
+	Sort(versions)
+
+	var got []string
+	for _, v := range versions {
+		got = append(got, v.String())
+	}
+
+	expected := []string{"0.1.3", "6.5.1", "11.3"}
+
+	assert.Equal(t, expected, got)
+}

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// Version represents a version.
+type Version struct {
+	raw string
+	v   semver.Version
+}
+
+// Make takes a string and converts it to a version. It supports the following:
+// * 1.2.3
+// * 1.2
+// * 1
+// * v1.2.3
+// * 1.2.3-build-1
+func Make(s string) (Version, error) {
+	versionStr := strings.TrimPrefix(s, "v")
+
+	parts := strings.SplitN(versionStr, ".", 3)
+
+	switch len(parts) {
+	case 3:
+		// nothing to do because we have three parts of a version
+	case 2:
+		// assume we have major and minor
+		versionStr = strings.Join(append(parts, "0"), ".")
+	case 1:
+		// assume we have major
+		versionStr = strings.Join(append(parts, "0", "0"), ".")
+	}
+
+	v, err := semver.Make(versionStr)
+	if err != nil {
+		return Version{}, err
+	}
+
+	return Version{
+		raw: s,
+		v:   v,
+	}, nil
+}
+
+func (v *Version) String() string {
+	return v.raw
+}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -1,0 +1,66 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMake(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		out   string
+		isErr bool
+	}{
+		{
+			name: "semantic version",
+			in:   "1.0.0",
+			out:  "1.0.0",
+		},
+		{
+			name: "major.minor",
+			in:   "1.0",
+			out:  "1.0",
+		},
+		{
+			name: "major",
+			in:   "1",
+			out:  "1",
+		},
+		{
+			name: "version has v prefix",
+			in:   "v1.2.3",
+			out:  "v1.2.3",
+		},
+		{
+			name: "semantic version with additional info",
+			in:   "1.2.3-beta.1",
+			out:  "1.2.3-beta.1",
+		},
+		{
+			name:  "empty version string",
+			in:    "",
+			isErr: true,
+		},
+		{
+			name:  "invalid version",
+			in:    "invalid",
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := Make(tc.in)
+
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tc.out, v.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixing regressions in the ksonnet helm integration:

* handle chart versions like `v0.1.3` when finding the latest version
* make kubernetes cluster version available to charts
* add ks helm repository verification tool