### PR TITLE
Support prototype resolution from environment-scoped packages

### DIFF
--- a/pkg/pkg/helm.go
+++ b/pkg/pkg/helm.go
@@ -141,6 +141,7 @@ func (h *Helm) Prototypes() (prototype.Prototypes, error) {
 		APIVersion: prototype.DefaultAPIVersion,
 		Kind:       prototype.DefaultKind,
 		Name:       h.prototypeName(),
+		Version:    latestVersion,
 		Template: prototype.SnippetSchema{
 			Description:      shortDescription,
 			ShortDescription: shortDescription,

--- a/pkg/pkg/local.go
+++ b/pkg/pkg/local.go
@@ -128,6 +128,7 @@ func (l *Local) Prototypes() (prototype.Prototypes, error) {
 		if err != nil {
 			return err
 		}
+		spec.Version = l.version
 
 		prototypes = append(prototypes, spec)
 		return nil

--- a/pkg/util/version/sort.go
+++ b/pkg/util/version/sort.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package version
 
 import "sort"

--- a/pkg/util/version/sort_test.go
+++ b/pkg/util/version/sort_test.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package version
 
 import (

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package version
 
 import (
@@ -45,6 +60,11 @@ func Make(s string) (Version, error) {
 	}, nil
 }
 
-func (v *Version) String() string {
+func (v Version) String() string {
 	return v.raw
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return v.v.LT(o.v)
 }

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -1,3 +1,18 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package version
 
 import (


### PR DESCRIPTION
Closes #713

To exercise:

```
ks init test-713 && cd test-713/
ks env add stage
ks pkg install --env stage incubator/nginx
ks prototype list
ks prototype preview io.ksonnet.pkg.nginx-simple --name myNginx
ks prototype use io.ksonnet.pkg.nginx-simple myNginx
```