### PR TITLE
Check component exists prior to delete in local

### DIFF
--- a/pkg/actions/param_delete.go
+++ b/pkg/actions/param_delete.go
@@ -117,6 +117,10 @@ func (pd *ParamDelete) deleteLocal(path []string) error {
 		return errors.Wrap(err, "could not find component")
 	}
 
+	if c == nil {
+		return errors.New("invalid component or param key")
+	}
+
 	if err := c.DeleteParam(path); err != nil {
 		return errors.Wrap(err, "delete param")
 	}


### PR DESCRIPTION
Closes #690 

Should not affect global path e.g.
```
ks param set replicas 4 --env default
ks param delete replicas --env default
```
Addresses case where `ks param delete <string>` where component name or param key is missing.

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>