### PR TITLE
Set Kubernetes namespace in helm engine options

### DIFF
--- a/pkg/helm/renderer_test.go
+++ b/pkg/helm/renderer_test.go
@@ -64,6 +64,9 @@ func TestRenderer_Render(t *testing.T) {
 
 				envConfig := &app.EnvironmentConfig{
 					KubernetesVersion: "v1.10.3",
+					Destination: &app.EnvironmentDestinationSpec{
+						Namespace: "Default",
+					},
 				}
 				a.On("Environment", "default").Return(envConfig, nil)
 
@@ -115,6 +118,9 @@ func TestRenderer_JsonnetNativeFunc(t *testing.T) {
 
 				envConfig := &app.EnvironmentConfig{
 					KubernetesVersion: "v1.10.3",
+					Destination: &app.EnvironmentDestinationSpec{
+						Namespace: "default",
+					},
 				}
 				a.On("Environment", "default").Return(envConfig, nil)
 


### PR DESCRIPTION
Fixes #723 

This change makes the current environment's namespace available to the helm rendering engine.

Signed-off-by: bryanl <bryanliles@gmail.com>