### PR TITLE
List environment-scoped packages in addition to globally-scoped packages

### DIFF
--- a/pkg/actions/registry_describe_test.go
+++ b/pkg/actions/registry_describe_test.go
@@ -43,17 +43,17 @@ func TestRegistryDescribe(t *testing.T) {
 
 			spec := &registry.Spec{
 				Libraries: registry.LibraryConfigs{
-					"apache":    &registry.LibaryConfig{Path: "apache"},
-					"efk":       &registry.LibaryConfig{Path: "efk"},
-					"mariadb":   &registry.LibaryConfig{Path: "mariadb"},
-					"memcached": &registry.LibaryConfig{Path: "memcached"},
-					"mongodb":   &registry.LibaryConfig{Path: "mongodb"},
-					"mysql":     &registry.LibaryConfig{Path: "mysql"},
-					"nginx":     &registry.LibaryConfig{Path: "nginx"},
-					"node":      &registry.LibaryConfig{Path: "node"},
-					"postres":   &registry.LibaryConfig{Path: "postgres"},
-					"redis":     &registry.LibaryConfig{Path: "redis"},
-					"tomcat":    &registry.LibaryConfig{Path: "tomcat"},
+					"apache":    &registry.LibraryConfig{Path: "apache"},
+					"efk":       &registry.LibraryConfig{Path: "efk"},
+					"mariadb":   &registry.LibraryConfig{Path: "mariadb"},
+					"memcached": &registry.LibraryConfig{Path: "memcached"},
+					"mongodb":   &registry.LibraryConfig{Path: "mongodb"},
+					"mysql":     &registry.LibraryConfig{Path: "mysql"},
+					"nginx":     &registry.LibraryConfig{Path: "nginx"},
+					"node":      &registry.LibraryConfig{Path: "node"},
+					"postres":   &registry.LibraryConfig{Path: "postgres"},
+					"redis":     &registry.LibraryConfig{Path: "redis"},
+					"tomcat":    &registry.LibraryConfig{Path: "tomcat"},
 				},
 			}
 

--- a/pkg/actions/testdata/pkg/list/installed.txt
+++ b/pkg/actions/testdata/pkg/list/installed.txt
@@ -1,3 +1,4 @@
 REGISTRY  NAME VERSION INSTALLED
 ========  ==== ======= =========
 incubator lib1 0.0.1   *
+incubator lib1 0.0.2   *

--- a/pkg/actions/testdata/pkg/list/output.json
+++ b/pkg/actions/testdata/pkg/list/output.json
@@ -8,6 +8,12 @@
 			"version": "0.0.1"
 		},
 		{
+			"installed": "*",
+			"name": "lib1",
+			"registry": "incubator",
+			"version": "0.0.2"
+		},
+		{
 			"installed": "",
 			"name": "lib2",
 			"registry": "incubator",

--- a/pkg/actions/testdata/pkg/list/output.txt
+++ b/pkg/actions/testdata/pkg/list/output.txt
@@ -1,4 +1,5 @@
 REGISTRY  NAME VERSION INSTALLED
 ========  ==== ======= =========
 incubator lib1 0.0.1   *
+incubator lib1 0.0.2   *
 incubator lib2 master

--- a/pkg/pkg/local.go
+++ b/pkg/pkg/local.go
@@ -74,6 +74,7 @@ func NewLocal(a app.App, name, registryName string, version string, installCheck
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshalling package configuration")
 	}
+	config.Version = version
 
 	return &Local{
 		pkg: pkg{

--- a/pkg/pkg/pkg.go
+++ b/pkg/pkg/pkg.go
@@ -76,6 +76,7 @@ func (p *pkg) String() string {
 		return "nil"
 	}
 
+	// TODO exclude @ if verion is empty
 	return fmt.Sprintf("%v/%v@%v", p.registryName, p.name, p.version)
 }
 
@@ -119,6 +120,15 @@ func (ic *DefaultInstallChecker) IsInstalled(name string) (bool, error) {
 
 	isInstalled := isGlobal || isLocal
 	return isInstalled, nil
+}
+
+// TrueInstallChecker implements an always-true InstallChecker.
+type TrueInstallChecker struct{}
+
+// IsInstalled always returns true, signaling we knew the package was installed when it was
+// bound to this installChecker.
+func (ic TrueInstallChecker) IsInstalled(name string) (bool, error) {
+	return true, nil
 }
 
 // Package is a ksonnet package.

--- a/pkg/registry/add_test.go
+++ b/pkg/registry/add_test.go
@@ -123,7 +123,7 @@ func TestAdd_Helm(t *testing.T) {
 			APIVersion: DefaultAPIVersion,
 			Kind:       DefaultKind,
 			Libraries: LibraryConfigs{
-				"chart": &LibaryConfig{
+				"chart": &LibraryConfig{
 					Version: "2.0.0",
 					Path:    "chart",
 				},

--- a/pkg/registry/fs_test.go
+++ b/pkg/registry/fs_test.go
@@ -152,7 +152,7 @@ func TestFs_FetchRegistrySpec(t *testing.T) {
 					APIVersion: DefaultAPIVersion,
 					Kind:       "ksonnet.io/registry",
 					Libraries: LibraryConfigs{
-						"apache": &LibaryConfig{
+						"apache": &LibraryConfig{
 							Path: "apache",
 						},
 					},

--- a/pkg/registry/github_test.go
+++ b/pkg/registry/github_test.go
@@ -215,9 +215,9 @@ func TestGithub_FetchRegistrySpec_nocache(t *testing.T) {
 		Kind:       "ksonnet.io/registry",
 		Version:    "12345",
 		Libraries: LibraryConfigs{
-			"apache": &LibaryConfig{
+			"apache": &LibraryConfig{
 				Path:    "apache",
-				Version: "master",
+				Version: "12345",
 			},
 		},
 	}

--- a/pkg/registry/helm.go
+++ b/pkg/registry/helm.go
@@ -100,7 +100,7 @@ func (h *Helm) FetchRegistrySpec() (*Spec, error) {
 			return nil, errors.Errorf("entries are invalid")
 		}
 
-		spec.Libraries[name] = &LibaryConfig{
+		spec.Libraries[name] = &LibraryConfig{
 			Path:    name,
 			Version: chart.Version,
 		}

--- a/pkg/registry/helm_test.go
+++ b/pkg/registry/helm_test.go
@@ -150,11 +150,11 @@ func TestHelm_FetchRegistrySpec(t *testing.T) {
 			APIVersion: DefaultAPIVersion,
 			Kind:       DefaultKind,
 			Libraries: LibraryConfigs{
-				"app-a": &LibaryConfig{
+				"app-a": &LibraryConfig{
 					Path:    "app-a",
 					Version: "0.1.0",
 				},
-				"app-b": &LibaryConfig{
+				"app-b": &LibraryConfig{
 					Path:    "app-b",
 					Version: "0.2.0",
 				},

--- a/pkg/registry/mocks/PackageManager.go
+++ b/pkg/registry/mocks/PackageManager.go
@@ -138,3 +138,26 @@ func (_m *PackageManager) Prototypes() (prototype.Prototypes, error) {
 
 	return r0, r1
 }
+
+// RemotePackages provides a mock function with given fields:
+func (_m *PackageManager) RemotePackages() ([]pkg.Package, error) {
+	ret := _m.Called()
+
+	var r0 []pkg.Package
+	if rf, ok := ret.Get(0).(func() []pkg.Package); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]pkg.Package)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/pkg/registry/schema.go
+++ b/pkg/registry/schema.go
@@ -188,11 +188,11 @@ func load(a app.App, path string) (*Spec, bool, error) {
 // Specs is a slice of *Spec.
 type Specs []*Spec
 
-// LibaryConfig is library reference.
-type LibaryConfig struct {
+// LibraryConfig is library reference.
+type LibraryConfig struct {
 	Version string `json:"version"`
 	Path    string `json:"path"`
 }
 
 // LibraryConfigs maps LibraryConfigs to a name.
-type LibraryConfigs map[string]*LibaryConfig
+type LibraryConfigs map[string]*LibraryConfig

--- a/pkg/registry/schema_test.go
+++ b/pkg/registry/schema_test.go
@@ -34,8 +34,8 @@ var (
 		Kind:       "ksonnet.io/registry",
 		Version:    "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 		Libraries: LibraryConfigs{
-			"apache": &LibaryConfig{
-				Version: "master",
+			"apache": &LibraryConfig{
+				Version: "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 				Path:    "apache",
 			},
 		},
@@ -54,9 +54,9 @@ func Test_Unmarshal(t *testing.T) {
 		Kind:       DefaultKind,
 		Version:    "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 		Libraries: LibraryConfigs{
-			"apache": &LibaryConfig{
+			"apache": &LibraryConfig{
 				Path:    "apache",
-				Version: "master",
+				Version: "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 			},
 		},
 	}
@@ -70,9 +70,9 @@ func TestSpec_Marshal(t *testing.T) {
 		Kind:       DefaultKind,
 		Version:    "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 		Libraries: LibraryConfigs{
-			"apache": &LibaryConfig{
+			"apache": &LibraryConfig{
 				Path:    "apache",
-				Version: "master",
+				Version: "40285d8a14f1ac5787e405e1023cf0c07f6aa28c",
 			},
 		},
 	}

--- a/pkg/registry/testdata/registry-old-with-gitversion.yaml
+++ b/pkg/registry/testdata/registry-old-with-gitversion.yaml
@@ -6,4 +6,4 @@ kind: ksonnet.io/registry
 libraries:
   apache:
     path: apache
-    version: master
+    version: 40285d8a14f1ac5787e405e1023cf0c07f6aa28c

--- a/pkg/registry/testdata/registry.yaml
+++ b/pkg/registry/testdata/registry.yaml
@@ -3,5 +3,5 @@ kind: ksonnet.io/registry
 libraries:
   apache:
     path: apache
-    version: master
+    version: 40285d8a14f1ac5787e405e1023cf0c07f6aa28c
 version: 40285d8a14f1ac5787e405e1023cf0c07f6aa28c


### PR DESCRIPTION
Part of #626

* Add RemotePackages method to package manager
* pkg list uses PackageManger rather than App
* Packages from GitHub registry inherit version from the registry,
  rather than that specified in registry.yaml.
* Rename registry.LibaryConfig -> LibraryConfig

Signed-off-by: Oren Shomron <shomron@gmail.com>

## Exercising the feature

```
ksdev init 626-pkg-list && cd 626-pkg-list

# Show remote packages
ksdev pkg list

# Install environment-scoped package
ksdev env add stage
ksdev pkg install --env stage incubator/nginx@58ea0ff91474d488ea50829042b45fe962bd2fa3

# Environment-scoped package is listed:
ksdev pkg install --env stage incubator/nginx@58ea0ff91474d488ea50829042b45fe962bd2fa3

...

incubator nginx     40285d8a14f1ac5787e405e1023cf0c07f6aa28c
incubator nginx     58ea0ff91474d488ea50829042b45fe962bd2fa3 *
...

# Install different version in global scope
ksdev pkg install incubator/nginx

# Both versions (one global, one environment scoped) are listed
ksdev pkg list --installed

...
incubator nginx     40285d8a14f1ac5787e405e1023cf0c07f6aa28c *
incubator nginx     58ea0ff91474d488ea50829042b45fe962bd2fa3 *
...

# Upgrade env-scoped package so both match
# NOTE `ksdev pkg install incubator/nginx` fails due to faulty collision logic!
sed -i -e 's/58ea0ff91474d488ea50829042b45fe962bd2fa3/40285d8a14f1ac5787e405e1023cf0c07f6aa28c/' app.yaml

# Show that only a single instance of this version is listed
ksdev pkg list | grep nginx

...
incubator nginx     40285d8a14f1ac5787e405e1023cf0c07f6aa28c *
...
```