### PR TITLE
All user to force install package with --force

### DIFF
--- a/docs/cli-reference/ks_pkg_install.md
+++ b/docs/cli-reference/ks_pkg_install.md
@@ -51,6 +51,7 @@ ks pkg install --env stage incubator/nginx@40285d8a14f1ac5787e405e1023cf0c07f6aa
 
 ```
       --env string    Environment to install package into (optional)
+      --force         Force installation
   -h, --help          help for install
       --name string   Name to give the dependency, to use within the ksonnet app
 ```

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -51,6 +51,8 @@ const (
 	OptionExtVarFiles = "ext-vars-files"
 	// OptionExtVars is jsonnet ext vars.
 	OptionExtVars = "ext-vars"
+	// OptionForce is force option.
+	OptionForce = "force"
 	// OptionFormat is format option.
 	OptionFormat = "format"
 	// OptionFs is fs option.

--- a/pkg/actions/pkg_install.go
+++ b/pkg/actions/pkg_install.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ksonnet/ksonnet/pkg/registry"
 )
 
-type libCacher func(app.App, registry.InstalledChecker, pkg.Descriptor, string) (*app.LibraryConfig, error)
+type libCacher func(app.App, registry.InstalledChecker, pkg.Descriptor, string, bool) (*app.LibraryConfig, error)
 
 type libUpdater func(name string, env string, spec *app.LibraryConfig) error
 
@@ -41,6 +41,7 @@ type PkgInstall struct {
 	libName     string
 	customName  string
 	envName     string
+	force       bool
 	checker     registry.InstalledChecker
 	libCacherFn libCacher
 	libUpdateFn libUpdater
@@ -59,6 +60,7 @@ func NewPkgInstall(m map[string]interface{}) (*PkgInstall, error) {
 		app:        a,
 		libName:    ol.LoadString(OptionLibName),
 		customName: ol.LoadString(OptionName),
+		force:      ol.LoadBool(OptionForce),
 		envName:    ol.LoadOptionalString(OptionEnvName),
 		checker:    registry.NewPackageManager(a),
 
@@ -80,7 +82,7 @@ func (pi *PkgInstall) Run() error {
 		return err
 	}
 
-	libCfg, err := pi.libCacherFn(pi.app, pi.checker, d, customName)
+	libCfg, err := pi.libCacherFn(pi.app, pi.checker, d, customName, pi.force)
 	if err != nil {
 		return err
 	}

--- a/pkg/actions/pkg_install_test.go
+++ b/pkg/actions/pkg_install_test.go
@@ -35,6 +35,7 @@ func TestPkgInstall(t *testing.T) {
 			OptionApp:     appMock,
 			OptionLibName: libName,
 			OptionName:    customName,
+			OptionForce:   false,
 		}
 
 		a, err := NewPkgInstall(in)
@@ -50,7 +51,7 @@ func TestPkgInstall(t *testing.T) {
 		}
 
 		var cacherCalled bool
-		fakeCacher := func(a app.App, checker registry.InstalledChecker, d pkg.Descriptor, cn string) (*app.LibraryConfig, error) {
+		fakeCacher := func(a app.App, checker registry.InstalledChecker, d pkg.Descriptor, cn string, force bool) (*app.LibraryConfig, error) {
 			cacherCalled = true
 			require.Equal(t, expectedD, d)
 			require.Equal(t, "customName", cn)

--- a/pkg/clicmd/flags.go
+++ b/pkg/clicmd/flags.go
@@ -33,6 +33,7 @@ const (
 	flagExtVar                = "ext-str"
 	flagExtVarFile            = "ext-str-file"
 	flagFilename              = "filename"
+	flagForce                 = "force"
 	flagFormat                = "format"
 	flagGcTag                 = "gc-tag"
 	flagGracePeriod           = "grace-period"

--- a/pkg/clicmd/pkg_install.go
+++ b/pkg/clicmd/pkg_install.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	vPkgInstallName = "pkg-install-name"
-	vPkgInstallEnv  = "pkg-install-env"
+	vPkgInstallName  = "pkg-install-name"
+	vPkgInstallEnv   = "pkg-install-env"
+	vPkgInstallForce = "pkg-install-force"
 
 	pkgInstallLong = `
 The ` + "`install`" + ` command caches a ksonnet library locally, and makes it available
@@ -82,6 +83,7 @@ func newPkgInstallCmd(a app.App) *cobra.Command {
 				actions.OptionLibName: args[0],
 				actions.OptionName:    viper.GetString(vPkgInstallName),
 				actions.OptionEnvName: viper.GetString(vPkgInstallEnv),
+				actions.OptionForce:   viper.GetBool(vPkgInstallForce),
 			}
 
 			return runAction(actionPkgInstall, m)
@@ -89,9 +91,13 @@ func newPkgInstallCmd(a app.App) *cobra.Command {
 	}
 
 	pkgInstallCmd.Flags().String(flagName, "", "Name to give the dependency, to use within the ksonnet app")
-	pkgInstallCmd.Flags().String(flagEnv, "", "Environment to install package into (optional)")
 	viper.BindPFlag(vPkgInstallName, pkgInstallCmd.Flags().Lookup(flagName))
+
+	pkgInstallCmd.Flags().String(flagEnv, "", "Environment to install package into (optional)")
 	viper.BindPFlag(vPkgInstallEnv, pkgInstallCmd.Flags().Lookup(flagEnv))
+
+	pkgInstallCmd.Flags().Bool(flagForce, false, "Force installation")
+	viper.BindPFlag(vPkgInstallForce, pkgInstallCmd.Flags().Lookup(flagForce))
 
 	return pkgInstallCmd
 }

--- a/pkg/clicmd/pkg_install_test.go
+++ b/pkg/clicmd/pkg_install_test.go
@@ -32,6 +32,7 @@ func Test_pkgInstallCmd(t *testing.T) {
 				actions.OptionLibName: "package-name",
 				actions.OptionName:    "",
 				actions.OptionEnvName: "",
+				actions.OptionForce:   false,
 			},
 		},
 		{
@@ -43,6 +44,19 @@ func Test_pkgInstallCmd(t *testing.T) {
 				actions.OptionLibName: "package-name",
 				actions.OptionName:    "",
 				actions.OptionEnvName: "production",
+				actions.OptionForce:   false,
+			},
+		},
+		{
+			name:   "force install",
+			args:   []string{"pkg", "install", "package-name", "--force"},
+			action: actionPkgInstall,
+			expected: map[string]interface{}{
+				actions.OptionApp:     nil,
+				actions.OptionLibName: "package-name",
+				actions.OptionName:    "",
+				actions.OptionEnvName: "",
+				actions.OptionForce:   true,
 			},
 		},
 		{

--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -30,7 +30,7 @@ import (
 // CacheDependency vendors registry dependencies.
 // TODO: create unit tests for this once mocks for this package are
 // worked out.
-func CacheDependency(a app.App, checker InstalledChecker, d pkg.Descriptor, customName string) (*app.LibraryConfig, error) {
+func CacheDependency(a app.App, checker InstalledChecker, d pkg.Descriptor, customName string, force bool) (*app.LibraryConfig, error) {
 	logger := log.WithFields(log.Fields{
 		"action":      "registry.CacheDependency",
 		"part":        d.Name,
@@ -93,7 +93,7 @@ func CacheDependency(a app.App, checker InstalledChecker, d pkg.Descriptor, cust
 	if err != nil {
 		return nil, errors.Wrapf(err, "checking package installed status")
 	}
-	if ok {
+	if ok && !force {
 		return nil, errors.Errorf("package '%s/%s@%s' already exists.",
 			libRef.Registry, libRef.Name, libRef.Version)
 	}

--- a/pkg/registry/cache_test.go
+++ b/pkg/registry/cache_test.go
@@ -71,7 +71,7 @@ func Test_CacheDependency(t *testing.T) {
 			var checker installedChecker
 			d := pkg.Descriptor{Registry: lib.Registry, Name: lib.Name}
 
-			_, err := CacheDependency(a, &checker, d, "")
+			_, err := CacheDependency(a, &checker, d, "", false)
 			require.NoError(t, err)
 
 			test.AssertExists(t, fs, filepath.Join(a.Root(), "vendor", lib.Registry, lib.Name, "parts.yaml"))


### PR DESCRIPTION
This feature is added to allow two versions of a package to be
installed. (e.g. having multiple versions of a helm chart installed)

cc: @GuessWhoSamFoo 

Signed-off-by: bryanl <bryanliles@gmail.com>