### PR TITLE
Show environment scope in pkg list

### DIFF
--- a/pkg/actions/testdata/pkg/list/installed.txt
+++ b/pkg/actions/testdata/pkg/list/installed.txt
@@ -1,4 +1,4 @@
-REGISTRY  NAME VERSION INSTALLED
-========  ==== ======= =========
-incubator lib1 0.0.1   *
-incubator lib1 0.0.2   *
+REGISTRY  NAME VERSION INSTALLED ENVIRONMENTS
+========  ==== ======= ========= ============
+incubator lib1 0.0.1   *         default, production
+incubator lib1 0.0.2   *         stage

--- a/pkg/actions/testdata/pkg/list/output.json
+++ b/pkg/actions/testdata/pkg/list/output.json
@@ -2,18 +2,21 @@
 	"kind": "pkgList",
 	"data": [
 		{
+			"environments": "default, production",
 			"installed": "*",
 			"name": "lib1",
 			"registry": "incubator",
 			"version": "0.0.1"
 		},
 		{
+			"environments": "stage",
 			"installed": "*",
 			"name": "lib1",
 			"registry": "incubator",
 			"version": "0.0.2"
 		},
 		{
+			"environments": "",
 			"installed": "",
 			"name": "lib2",
 			"registry": "incubator",

--- a/pkg/actions/testdata/pkg/list/output.txt
+++ b/pkg/actions/testdata/pkg/list/output.txt
@@ -1,5 +1,5 @@
-REGISTRY  NAME VERSION INSTALLED
-========  ==== ======= =========
-incubator lib1 0.0.1   *
-incubator lib1 0.0.2   *
+REGISTRY  NAME VERSION INSTALLED ENVIRONMENTS
+========  ==== ======= ========= ============
+incubator lib1 0.0.1   *         default, production
+incubator lib1 0.0.2   *         stage
 incubator lib2 master

--- a/pkg/registry/mocks/PackageManager.go
+++ b/pkg/registry/mocks/PackageManager.go
@@ -70,6 +70,29 @@ func (_m *PackageManager) IsInstalled(d pkg.Descriptor) (bool, error) {
 	return r0, r1
 }
 
+// PackageEnvironments provides a mock function with given fields: _a0
+func (_m *PackageManager) PackageEnvironments(_a0 pkg.Package) ([]*app.EnvironmentConfig, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*app.EnvironmentConfig
+	if rf, ok := ret.Get(0).(func(pkg.Package) []*app.EnvironmentConfig); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*app.EnvironmentConfig)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(pkg.Package) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Packages provides a mock function with given fields:
 func (_m *PackageManager) Packages() ([]pkg.Package, error) {
 	ret := _m.Called()


### PR DESCRIPTION
Closes #626

Signed-off-by: Oren Shomron <shomron@gmail.com>

## Exercising the feature 🏃 🏋️‍♀️ 

```
ks init pkg-list && cd pkg-list
ks env add dev
ks env add stage

ks pkg install incubator/nginx@master
ks pkg install --env stage --force incubator/nginx@master
ks pkg install --env dev incubator/nginx@consistency

ks pkg install --env dev incubator/apache@master
ks pkg install --env stage --force incubator/apache@master

ks pkg list --installed

...

REGISTRY  NAME   VERSION                                  INSTALLED ENVIRONMENTS
========  ====   =======                                  ========= ============
incubator apache 40285d8a14f1ac5787e405e1023cf0c07f6aa28c *         dev, stage
incubator nginx  40285d8a14f1ac5787e405e1023cf0c07f6aa28c *         stage
incubator nginx  58ea0ff91474d488ea50829042b45fe962bd2fa3 *         dev
...
```