### PR TITLE
render helm templates with multiple objects

### DIFF
--- a/pkg/actions/import.go
+++ b/pkg/actions/import.go
@@ -206,7 +206,12 @@ func (i *Import) importFile(fileName string) error {
 }
 
 func (i *Import) createYAML(fileName, base, ext string) error {
-	readers, err := utilyaml.Decode(i.app.Fs(), fileName)
+	f, err := i.app.Fs().Open(fileName)
+	if err != nil {
+		return errors.Wrapf(err, "opening %q", fileName)
+	}
+
+	readers, err := utilyaml.Decode(f)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some helm charts return multiple Kubernetes objects. The YAML parsing libs we have only will take the first and silently ignore the rest. This change breaks the returns files up into multiple objects so everything is accounted for.

Signed-off-by: bryanl <bryanliles@gmail.com>