### PR TITLE
Add /tmp to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine as build
 ARG LD_FLAGS
 WORKDIR /go/src/github.com/ksonnet/ksonnet
 COPY . /go/src/github.com/ksonnet/ksonnet
-RUN CGO_ENABLED=0 GOOS=linux go build -o ks -ldflags="${LD_FLAGS}" ./cmd/ks
+RUN CGO_ENABLED=0 GOOS=linux go build -o ks -ldflags="${LD_FLAGS} -s -w" ./cmd/ks
 
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
@@ -10,4 +10,6 @@ RUN apk --update add ca-certificates
 FROM scratch
 COPY --from=certs /etc/ssl/certs/* /etc/ssl/certs/
 COPY --from=build /go/src/github.com/ksonnet/ksonnet/ks /bin/ks
+VOLUME /tmp
+
 ENTRYPOINT ["/bin/ks"]


### PR DESCRIPTION
This change:

* removes debugging data from binary
* adds a /tmp directory to the generated image

Signed-off-by: Bryan Liles <bryanliles@gmail.com>