### PR TITLE
Use object in cluster for basis for three way merge instead of new ob…

### DIFF
--- a/pkg/cluster/merger.go
+++ b/pkg/cluster/merger.go
@@ -124,7 +124,7 @@ func (p *defaultObjectMerger) Merge(namespace string, obj *unstructured.Unstruct
 		}
 	}
 
-	modified, err := runtime.Encode(encoder, info.Object)
+	modified, err := runtime.Encode(encoder, obj)
 	if err != nil {
 		return nil, errors.Wrap(err, "encode modified object")
 	}
@@ -257,7 +257,8 @@ func (p *patcher) patchSimple(obj runtime.Object, modified []byte, source, names
 		if p.openapiSchema != nil {
 			if schema = p.openapiSchema.LookupResource(p.mapping.GroupVersionKind); schema != nil {
 				lookupPatchMeta = strategicpatch.PatchMetaFromOpenAPI{Schema: schema}
-				if openapiPatch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.overwrite); err != nil {
+				openapiPatch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.overwrite)
+				if err != nil {
 					fmt.Fprintf(errOut, "warning: error calculating patch from openapi spec: %v\n", err)
 				} else {
 					patchType = types.StrategicMergePatchType

--- a/pkg/cluster/merger_test.go
+++ b/pkg/cluster/merger_test.go
@@ -77,6 +77,8 @@ func Test_merger_merge(t *testing.T) {
 		},
 	}
 
+	isPatched := false
+
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: unstructuredSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -87,6 +89,8 @@ func Test_merger_merge(t *testing.T) {
 				defer req.Body.Close()
 				_, err := convertToObject(req.Body)
 				require.NoError(t, err)
+
+				isPatched = true
 
 				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, clusterService)}, nil
 			default:
@@ -148,6 +152,8 @@ func Test_merger_merge(t *testing.T) {
 
 	_, err := om.Merge("testing", obj)
 	require.NoError(t, err)
+
+	require.True(t, isPatched)
 }
 
 type fakeObjectMerger struct {


### PR DESCRIPTION
This change modifies the merge strategy to use the object in the
basis for the patch rather than the modified object. This allows
the three way merge to detect changes in the new object.

Signed-off-by: bryanl <bryanliles@gmail.com>