### PR TITLE
fix verbose error message in generate cli

### DIFF
--- a/pkg/prototype/flags.go
+++ b/pkg/prototype/flags.go
@@ -40,6 +40,7 @@ func BindFlags(p *Prototype) (fs *pflag.FlagSet, err error) {
 
 	fs.String("values-file", "", "Prototype values file (file returns a Jsonnet object)")
 	fs.String("module", "", "Component module")
+       fs.CountP("verbose", "v", "Increase verbosity. May be given multiple times.")
 
 	for _, param := range p.RequiredParams() {
 		if fs.Lookup(param.Name) != nil {

--- a/pkg/prototype/flags_test.go
+++ b/pkg/prototype/flags_test.go
@@ -60,6 +60,7 @@ func TestBindFlags(t *testing.T) {
 		"module":      "Component module",
 		"optional":    "optional",
 		"values-file": "Prototype values file (file returns a Jsonnet object)",
+               "verbose":     "Increase verbosity. May be given multiple times.",
 	}
 
 	var seenFlags []string


### PR DESCRIPTION
When use _ks generate_
```
$ ks generate --help
...
Global Flags:
  -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
```

if use _ks generate_ with _--verbose(or -v)_, we meet error msg

```
$ ks generate deployed-service guestbook-ui   \
--image gcr.io/heptio-images/ks-guestbook-demo:0.1  \
--type ClusterIP \
--verbose=-1
```

> unknown flag: --verbose
> Usage of prototype-flags:
>       --containerPort string   Container port for service to target. (default "80")
>       --image string           Container image to deploy
>       --module string          Component module
>       --name string            Name of the service and deployment resources
>       --replicas string        Number of replicas (default "1")
>       --servicePort string     Port for the service to expose. (default "80")
>       --type string            Type of service to expose (default "ClusterIP")
>       --values-file string     Prototype values file (file returns a Jsonnet object)
> ERROR parse preview args: unknown flag: --verbose

Actually, present _ks generate_ command doesn't send any debug msg, however _verbose_ flag is gobal option, then we could use it in any command.

then, I added verbose to prototype-flags.