### PR TITLE
ks upgrade canonicalizes environment target separators (/ -> .)

### DIFF
--- a/pkg/app/app010.go
+++ b/pkg/app/app010.go
@@ -267,6 +267,10 @@ func (a *App010) Upgrade(dryRun bool) error {
 	if a.config == nil {
 		return errors.Errorf("invalid app - config is nil")
 	}
+	if dryRun {
+		return nil
+	}
+
 	a.config.APIVersion = "0.2.0"
 	return a.save()
 }

--- a/pkg/upgrade/testdata/app010_env_targets.yaml
+++ b/pkg/upgrade/testdata/app010_env_targets.yaml
@@ -1,0 +1,39 @@
+apiVersion: 0.1.0
+environments:
+  default:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: default
+    targets:
+    - /
+  us-east/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-east/test
+    targets:
+    - /
+    - path/to/module
+    - path/to/other/module
+  us-west/prod:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/prod
+  us-west/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/test
+kind: ksonnet.io/app
+name: test-get-envs
+registries:
+  incubator:
+    protocol: ""
+    uri: ""
+version: 0.0.1

--- a/pkg/upgrade/testdata/app020_env_targets.yaml
+++ b/pkg/upgrade/testdata/app020_env_targets.yaml
@@ -1,0 +1,39 @@
+apiVersion: 0.2.0
+environments:
+  default:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: default
+    targets:
+    - /
+  us-east/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-east/test
+    targets:
+    - /
+    - path.to.module
+    - path.to.other.module
+  us-west/prod:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/prod
+  us-west/test:
+    destination:
+      namespace: some-namespace
+      server: http://example.com
+    k8sVersion: v1.7.0
+    path: us-west/test
+kind: ksonnet.io/app
+name: test-get-envs
+registries:
+  incubator:
+    protocol: ""
+    uri: ""
+version: 0.0.1


### PR DESCRIPTION
Fixes #766

Signed-off-by: Oren Shomron <shomron@gmail.com>