### PR TITLE
ks diff support for objects outside of the "all" category

### DIFF
--- a/pkg/cluster/apply.go
+++ b/pkg/cluster/apply.go
@@ -72,7 +72,7 @@ type Apply struct {
 	// these make it easier to test Apply.
 	findObjectsFn         findObjectsFn
 	resourceClientFactory resourceClientFactoryFn
-	clientOpts            *clientOpts
+	clientOpts            *Clients
 	objectInfo            ObjectInfo
 	ksonnetObjectFactory  func() ksonnetObject
 	upserterFactory       func() Upserter
@@ -102,7 +102,7 @@ func RunApply(config ApplyConfig, opts ...ApplyOpts) error {
 	}
 
 	if a.clientOpts == nil {
-		co, err := genClientOpts(a.App, a.ClientConfig, a.EnvName)
+		co, err := GenClients(a.App, a.ClientConfig, a.EnvName)
 		if err != nil {
 			return err
 		}
@@ -278,17 +278,4 @@ func (a *Apply) dryRunText() string {
 	}
 
 	return text
-}
-
-func genClientOpts(a app.App, clientConfig *client.Config, envName string) (clientOpts, error) {
-	clientPool, discovery, namespace, err := clientConfig.RestClient(a, &envName)
-	if err != nil {
-		return clientOpts{}, err
-	}
-
-	return clientOpts{
-		clientPool: clientPool,
-		discovery:  discovery,
-		namespace:  namespace,
-	}, nil
 }

--- a/pkg/cluster/apply_test.go
+++ b/pkg/cluster/apply_test.go
@@ -59,7 +59,7 @@ func Test_Apply(t *testing.T) {
 		setupApp := func(apply *Apply) {
 			obj := &unstructured.Unstructured{Object: genObject()}
 
-			apply.clientOpts = &clientOpts{}
+			apply.clientOpts = &Clients{}
 
 			apply.findObjectsFn = func(a app.App, envName string, componentNames []string) ([]*unstructured.Unstructured, error) {
 				objects := []*unstructured.Unstructured{obj}
@@ -96,7 +96,7 @@ func Test_Apply_dry_run(t *testing.T) {
 		setupApp := func(apply *Apply) {
 			obj := &unstructured.Unstructured{Object: genObject()}
 
-			apply.clientOpts = &clientOpts{}
+			apply.clientOpts = &Clients{}
 
 			apply.findObjectsFn = func(a app.App, envName string, componentNames []string) ([]*unstructured.Unstructured, error) {
 				objects := []*unstructured.Unstructured{obj}
@@ -132,8 +132,8 @@ func Test_Apply_retry_on_conflict(t *testing.T) {
 		setupApp := func(apply *Apply) {
 			obj := &unstructured.Unstructured{Object: genObject()}
 
-			apply.clientOpts = &clientOpts{}
-			apply.resourceClientFactory = func(opts clientOpts, object runtime.Object) (ResourceClient, error) {
+			apply.clientOpts = &Clients{}
+			apply.resourceClientFactory = func(opts Clients, object runtime.Object) (ResourceClient, error) {
 				rc := &mocks.ResourceClient{}
 				rc.On("Get", mock.Anything).Return(obj, nil)
 				return rc, nil

--- a/pkg/cluster/client_test.go
+++ b/pkg/cluster/client_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Test_newResourceClient(t *testing.T) {
-	aOpts := clientOpts{}
+	aOpts := Clients{}
 	aObject := &unstructured.Unstructured{}
 
 	mockDI := &mockDynamicInterface{}
@@ -101,7 +101,7 @@ func Test_resourceClient_Patch(t *testing.T) {
 }
 
 func withMockResourceClient(t *testing.T, fn func(rc *resourceClient, di *mockDynamicInterface, ob *unstructured.Unstructured)) {
-	aOpts := clientOpts{}
+	aOpts := Clients{}
 	aObject := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -34,11 +34,11 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-type genClientOptsFn func(a app.App, c *client.Config, envName string) (clientOpts, error)
+type genClientOptsFn func(a app.App, c *client.Config, envName string) (Clients, error)
 
 type clientFactoryFn func(dynamic.ClientPool, discovery.DiscoveryInterface, runtime.Object, string) (dynamic.ResourceInterface, error)
 
-type resourceClientFactoryFn func(opts clientOpts, object runtime.Object) (ResourceClient, error)
+type resourceClientFactoryFn func(opts Clients, object runtime.Object) (ResourceClient, error)
 
 type discoveryFn func(a app.App, clientConfig *client.Config, envName string) (discovery.DiscoveryInterface, error)
 
@@ -47,11 +47,6 @@ type validateObjectFn func(d discovery.DiscoveryInterface,
 
 type findObjectsFn func(a app.App, envName string,
 	componentNames []string) ([]*unstructured.Unstructured, error)
-
-func loadDiscovery(a app.App, clientConfig *client.Config, envName string) (discovery.DiscoveryInterface, error) {
-	_, d, _, err := clientConfig.RestClient(a, &envName)
-	return d, err
-}
 
 func findObjects(a app.App, envName string, componentNames []string) ([]*unstructured.Unstructured, error) {
 	p := pipeline.New(a, envName)
@@ -68,7 +63,7 @@ func stringListContains(list []string, value string) bool {
 }
 
 // func gcDelete(clientpool dynamic.ClientPool, disco discovery.DiscoveryInterface, version *utils.ServerVersion, o runtime.Object) error {
-func gcDelete(options clientOpts, rcFactory resourceClientFactoryFn, version *utils.ServerVersion, o runtime.Object) error {
+func gcDelete(options Clients, rcFactory resourceClientFactoryFn, version *utils.ServerVersion, o runtime.Object) error {
 	obj, err := meta.Accessor(o)
 	if err != nil {
 		return fmt.Errorf("Unexpected object type: %s", err)
@@ -108,7 +103,7 @@ func gcDelete(options clientOpts, rcFactory resourceClientFactoryFn, version *ut
 	return nil
 }
 
-func walkObjects(co clientOpts, listopts metav1.ListOptions, callback func(runtime.Object) error) error {
+func walkObjects(co Clients, listopts metav1.ListOptions, callback func(runtime.Object) error) error {
 	rsrclists, err := co.discovery.ServerResources()
 	if err != nil {
 		return err

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -56,7 +56,7 @@ func RunDelete(config DeleteConfig, opts ...DeleteOpts) error {
 	d := &Delete{
 		DeleteConfig:          config,
 		findObjectsFn:         findObjects,
-		genClientOptsFn:       genClientOpts,
+		genClientOptsFn:       GenClients,
 		resourceClientFactory: resourceClientFactory,
 		objectInfo:            &objectInfo{},
 	}

--- a/pkg/cluster/discovery.go
+++ b/pkg/cluster/discovery.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cluster
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// sortResources sources resources by moving extensions to the end of the slice. The order of all
+// the other resources is preserved.
+func sortResources(resources []*metav1.APIResourceList) {
+	sort.SliceStable(resources, func(i, j int) bool {
+		left := resources[i]
+		leftGV, _ := schema.ParseGroupVersion(left.GroupVersion)
+		// not checking error because it should be impossible to fail to parse data coming from the
+		// apiserver
+		if leftGV.Group == "extensions" {
+			// always sort extensions at the bottom by saying left is "greater"
+			return false
+		}
+
+		right := resources[j]
+		rightGV, _ := schema.ParseGroupVersion(right.GroupVersion)
+		// not checking error because it should be impossible to fail to parse data coming from the
+		// apiserver
+		if rightGV.Group == "extensions" {
+			// always sort extensions at the bottom by saying left is "less"
+			return true
+		}
+
+		return i < j
+	})
+}

--- a/pkg/cluster/ksonnet_object.go
+++ b/pkg/cluster/ksonnet_object.go
@@ -25,7 +25,7 @@ import (
 // ksonnetObject can merge an object with its cluster state. This is required because
 // some fields will be overwritten if applied again (e.g. Server NodePort).
 type ksonnetObject interface {
-	MergeFromCluster(co clientOpts, obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	MergeFromCluster(co Clients, obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
 }
 
 type defaultKsonnetObject struct {
@@ -42,7 +42,7 @@ func newDefaultKsonnetObject(factory cmdutil.Factory) *defaultKsonnetObject {
 	}
 }
 
-func (ko *defaultKsonnetObject) MergeFromCluster(co clientOpts, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (ko *defaultKsonnetObject) MergeFromCluster(co Clients, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	mergedObject, err := ko.objectMerger.Merge(co.namespace, obj)
 	if err != nil {
 		cause := errors.Cause(err)

--- a/pkg/cluster/ksonnet_object_test.go
+++ b/pkg/cluster/ksonnet_object_test.go
@@ -85,7 +85,7 @@ func Test_defaultKsonnetObject_MergeFromCluster(t *testing.T) {
 			factory := cmdtesting.NewTestFactory()
 			defer factory.Cleanup()
 
-			co := clientOpts{}
+			co := Clients{}
 
 			ko := newDefaultKsonnetObject(factory)
 			ko.objectMerger = tc.objectMerger
@@ -109,6 +109,6 @@ type fakeKsonnetObject struct {
 
 var _ (ksonnetObject) = (*fakeKsonnetObject)(nil)
 
-func (ko *fakeKsonnetObject) MergeFromCluster(co clientOpts, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (ko *fakeKsonnetObject) MergeFromCluster(co Clients, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	return ko.obj, ko.err
 }

--- a/pkg/cluster/object_describer.go
+++ b/pkg/cluster/object_describer.go
@@ -32,7 +32,7 @@ type objectDescriber interface {
 // defaultObjectDescriber is the default implementation of objectDescriber.
 type defaultObjectDescriber struct {
 	// clientOpts are Kubernetes client otpions.
-	clientOpts clientOpts
+	clientOpts Clients
 
 	// objectInfo locates information for Kubernetes objects.
 	objectInfo ObjectInfo
@@ -41,7 +41,7 @@ type defaultObjectDescriber struct {
 var _ objectDescriber = (*defaultObjectDescriber)(nil)
 
 // newDefaultObjectDescriber creates an instance of defaultObjectDescriber.
-func newDefaultObjectDescriber(co clientOpts, oi ObjectInfo) (*defaultObjectDescriber, error) {
+func newDefaultObjectDescriber(co Clients, oi ObjectInfo) (*defaultObjectDescriber, error) {
 	if oi == nil {
 		return nil, errors.Errorf("object info is required")
 	}

--- a/pkg/cluster/object_describer_test.go
+++ b/pkg/cluster/object_describer_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_defaultObjectDescriber_Describe(t *testing.T) {
-	co := clientOpts{}
+	co := Clients{}
 	oi := &fakeObjectInfo{resourceName: "name"}
 
 	od, err := newDefaultObjectDescriber(co, oi)

--- a/pkg/cluster/upsert.go
+++ b/pkg/cluster/upsert.go
@@ -38,7 +38,7 @@ type defaultUpserter struct {
 	ApplyConfig
 
 	// clientOpts are Kubernetes client options.
-	clientOpts clientOpts
+	clientOpts Clients
 
 	// objectInfo is the utility for location information about objects.
 	objectInfo ObjectInfo
@@ -53,7 +53,7 @@ type defaultUpserter struct {
 var _ Upserter = (*defaultUpserter)(nil)
 
 // newDefaultUpserter creates an instance of defaultUpserter.
-func newDefaultUpserter(ac ApplyConfig, oi ObjectInfo, co clientOpts, rfc resourceClientFactoryFn) (*defaultUpserter, error) {
+func newDefaultUpserter(ac ApplyConfig, oi ObjectInfo, co Clients, rfc resourceClientFactoryFn) (*defaultUpserter, error) {
 	describer, err := newDefaultObjectDescriber(co, oi)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating object describer")
@@ -114,7 +114,7 @@ func (u *defaultUpserter) updateObject(rc ResourceClient, obj *unstructured.Unst
 }
 
 // createObject attempts to create an object in the cluster.
-func (u *defaultUpserter) createObject(co clientOpts, rc ResourceClient, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (u *defaultUpserter) createObject(co Clients, rc ResourceClient, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	newObj, err := rc.Create()
 	log.Debugf("Create(%s) returned (%v, %v)", obj.GetName(), newObj, err)
 

--- a/pkg/cluster/upsert_test.go
+++ b/pkg/cluster/upsert_test.go
@@ -150,10 +150,10 @@ func Test_defaultUpserter_Upsert(t *testing.T) {
 
 			oi := &fakeObjectInfo{resourceName: "name"}
 
-			co := clientOpts{}
+			co := Clients{}
 
 			rc := tc.initResourceClient(t, obj)
-			rfc := func(clientOpts, runtime.Object) (ResourceClient, error) {
+			rfc := func(Clients, runtime.Object) (ResourceClient, error) {
 				return rc, nil
 			}
 


### PR DESCRIPTION
This PR allows ks diff to consider objects that are not part of the
"all" category, e.g. Ingress, Certificate.

Additionally, the cluster settings of the environment being diffed are
respected and override the current context when deciding where to
connect.

Fixes #803
Fixes #809

Signed-off-by: Oren Shomron <shomron@gmail.com>