### PR TITLE
Remove override flag from ks env rm

### DIFF
--- a/e2e/env_test.go
+++ b/e2e/env_test.go
@@ -138,7 +138,7 @@ var _ = Describe("ks env", func() {
 					"default", e.serverVersion(), "default", "*", "http://example.com")
 				a.checkEnvs(expected)
 
-				o = a.runKs("env", "rm", "-o", "default")
+				o = a.runKs("env", "rm", "default")
 				assertExitStatus(o, 0)
 
 				a.checkEnvs(genEnvList(e.serverVersion()))

--- a/pkg/actions/env_rm.go
+++ b/pkg/actions/env_rm.go
@@ -46,9 +46,8 @@ func NewEnvRm(m map[string]interface{}) (*EnvRm, error) {
 	ol := newOptionLoader(m)
 
 	ea := &EnvRm{
-		app:        ol.LoadApp(),
-		envName:    ol.LoadString(OptionEnvName),
-		isOverride: ol.LoadBool(OptionOverride),
+		app:     ol.LoadApp(),
+		envName: ol.LoadString(OptionEnvName),
 
 		envDeleteFn: env.Delete,
 	}
@@ -62,9 +61,14 @@ func NewEnvRm(m map[string]interface{}) (*EnvRm, error) {
 
 // Run assigns targets to an environment.
 func (er *EnvRm) Run() error {
+	env, err := er.app.Environment(er.envName)
+	if err != nil {
+		return err
+	}
+
 	return er.envDeleteFn(
 		er.app,
 		er.envName,
-		er.isOverride,
+		env.IsOverride(),
 	)
 }

--- a/pkg/actions/env_rm_test.go
+++ b/pkg/actions/env_rm_test.go
@@ -25,9 +25,17 @@ import (
 )
 
 func TestEnvRm(t *testing.T) {
+	aName := "my-app"
+	aIsOverride := false
+
+	environmentMockFn := func(name string) *app.EnvironmentConfig {
+		return &app.EnvironmentConfig{
+			Name: name,
+		}
+	}
+
 	withApp(t, func(appMock *amocks.App) {
-		aName := "my-app"
-		aIsOverride := false
+		appMock.On("Environment", aName).Return(environmentMockFn, nil)
 
 		in := map[string]interface{}{
 			OptionApp:      appMock,

--- a/pkg/clicmd/env_rm.go
+++ b/pkg/clicmd/env_rm.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ksonnet/ksonnet/pkg/actions"
 	"github.com/ksonnet/ksonnet/pkg/app"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -64,17 +63,13 @@ func newEnvRmCmd(a app.App) *cobra.Command {
 			}
 
 			m := map[string]interface{}{
-				actions.OptionApp:      a,
-				actions.OptionEnvName:  args[0],
-				actions.OptionOverride: viper.GetBool(vEnvRmOverride),
+				actions.OptionApp:     a,
+				actions.OptionEnvName: args[0],
 			}
 
 			return runAction(actionEnvRm, m)
 		},
 	}
-
-	envRmCmd.Flags().BoolP(flagOverride, shortOverride, false, "Remove the overridden environment")
-	viper.BindPFlag(vEnvRmOverride, envRmCmd.Flags().Lookup(flagOverride))
 
 	return envRmCmd
 


### PR DESCRIPTION
Closes #822 

This change ensures `ks rm` is consistent with `ks env set` with overriding.

 - `ks env rm` no longer has an `--override` flag
 - When overriding an env, it is not possible to change the non-overriden env.

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>