### PR TITLE
Garbage collection for vendored packages

### DIFF
--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -245,6 +245,7 @@ func withApp(t *testing.T, fn func(*mocks.App)) {
 	appMock := &mocks.App{}
 	appMock.On("Fs").Return(fs)
 	appMock.On("Root").Return("/")
+	appMock.On("VendorPath").Return("/vendor")
 
 	fn(appMock)
 }

--- a/pkg/actions/pkg_describe.go
+++ b/pkg/actions/pkg_describe.go
@@ -21,6 +21,7 @@ import (
 	"text/template"
 
 	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/pkg"
 	"github.com/ksonnet/ksonnet/pkg/registry"
 )
 
@@ -69,7 +70,12 @@ func NewPkgDescribe(m map[string]interface{}) (*PkgDescribe, error) {
 
 // Run describes a package.
 func (pd *PkgDescribe) Run() error {
-	p, err := pd.packageManager.Find(pd.pkgName)
+	d, err := pkg.Parse(pd.pkgName)
+	if err != nil {
+		return err
+	}
+
+	p, err := pd.packageManager.Find(d)
 	if err != nil {
 		return err
 	}

--- a/pkg/actions/pkg_describe_test.go
+++ b/pkg/actions/pkg_describe_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/ksonnet/ksonnet/pkg/app"
+	"github.com/ksonnet/ksonnet/pkg/pkg"
 	"github.com/ksonnet/ksonnet/pkg/prototype"
 	"github.com/pkg/errors"
 
@@ -34,6 +35,7 @@ import (
 )
 
 func TestPkgDescribe(t *testing.T) {
+	d := pkg.Descriptor{Name: "apache"}
 
 	cases := []struct {
 		name        string
@@ -52,7 +54,7 @@ func TestPkgDescribe(t *testing.T) {
 				p.On("IsInstalled").Return(false, nil)
 
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(p, nil)
+				pkgManager.On("Find", d).Return(p, nil)
 
 				return pkgManager
 			},
@@ -76,7 +78,7 @@ func TestPkgDescribe(t *testing.T) {
 				p.On("Prototypes").Return(prototypes, nil)
 
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(p, nil)
+				pkgManager.On("Find", d).Return(p, nil)
 
 				return pkgManager
 			},
@@ -86,7 +88,7 @@ func TestPkgDescribe(t *testing.T) {
 			isErr: true,
 			pkgManager: func() registry.PackageManager {
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(nil, errors.New("failed"))
+				pkgManager.On("Find", d).Return(nil, errors.New("failed"))
 
 				return pkgManager
 			},
@@ -100,7 +102,7 @@ func TestPkgDescribe(t *testing.T) {
 				p.On("IsInstalled").Return(false, errors.New("failed"))
 
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(p, nil)
+				pkgManager.On("Find", d).Return(p, nil)
 
 				return pkgManager
 			},
@@ -115,7 +117,7 @@ func TestPkgDescribe(t *testing.T) {
 				p.On("IsInstalled").Return(true, nil)
 
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(p, nil)
+				pkgManager.On("Find", d).Return(p, nil)
 
 				return pkgManager
 			},
@@ -129,7 +131,7 @@ func TestPkgDescribe(t *testing.T) {
 				p.On("IsInstalled").Return(false, nil)
 
 				pkgManager := &regmocks.PackageManager{}
-				pkgManager.On("Find", "apache").Return(p, nil)
+				pkgManager.On("Find", d).Return(p, nil)
 
 				return pkgManager
 			},

--- a/pkg/app/schema.go
+++ b/pkg/app/schema.go
@@ -563,3 +563,19 @@ func (s *Spec) UpdateEnvironmentConfig(name string, env *EnvironmentConfig) erro
 	s.Environments[env.Name] = env
 	return nil
 }
+
+func (l LibraryConfig) String() string {
+	switch {
+	case l.Registry != "" && l.Version != "":
+		return fmt.Sprintf("%s/%s@%s", l.Registry, l.Name, l.Version)
+	case l.Registry != "" && l.Version == "":
+		return fmt.Sprintf("%s/%s", l.Registry, l.Name)
+	case l.Registry == "" && l.Version != "":
+		return fmt.Sprintf("%s@%s", l.Name, l.Version)
+	case l.Registry == "" && l.Version == "":
+		return l.Name
+	default:
+		// Not sure which case we missed, just default to verbose
+		return fmt.Sprintf("%s/%s@%s", l.Registry, l.Name, l.Version)
+	}
+}

--- a/pkg/pkg/helm.go
+++ b/pkg/pkg/helm.go
@@ -198,3 +198,16 @@ func (h *Helm) Path() string {
 	}
 	return path
 }
+
+// HelmVendorPath returns a path for vendoring the described package.
+func HelmVendorPath(a app.App, d Descriptor) string {
+	if a == nil {
+		return ""
+	}
+
+	path, err := chartConfigDir(a, d.Name, d.Registry, d.Version)
+	if err != nil {
+		return ""
+	}
+	return path
+}

--- a/pkg/pkg/local.go
+++ b/pkg/pkg/local.go
@@ -204,3 +204,12 @@ func (l *Local) Path() string {
 
 	return buildPath(l.a, l.registryName, l.name, l.version)
 }
+
+// LocalVendorPath returns a path for vendoring the described package.
+func LocalVendorPath(a app.App, d Descriptor) string {
+	if a == nil {
+		return ""
+	}
+
+	return buildPath(a, d.Registry, d.Name, d.Version)
+}

--- a/pkg/pkg/name_test.go
+++ b/pkg/pkg/name_test.go
@@ -40,6 +40,10 @@ func Test_Parse(t *testing.T) {
 			expected: Descriptor{Registry: "parts-infra", Name: "contour", Version: "0.1.0"},
 		},
 		{
+			name:     "contour@0.1.0",
+			expected: Descriptor{Registry: "", Name: "contour", Version: "0.1.0"},
+		},
+		{
 			name:  "@foo/bar@baz@doh",
 			isErr: true,
 		},

--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -152,16 +152,11 @@ func versionAndVendorRelPath(lib *app.LibraryConfig, vendorRoot string, relPath 
 	// Version the path
 	var versionedPath string
 	if lib.Version != "" {
-		//filepath.ToSlash()
 		parts := strings.SplitN(filepath.ToSlash(relPath), "/", -1)
 		if parts[0] == lib.Name {
 			parts[0] = fmt.Sprintf("%s@%s", lib.Name, lib.Version)
 		}
 		versionedPath = filepath.FromSlash(strings.Join(parts, "/"))
-
-		// oldPrefix := filepath.Join(lib.Registry, lib.Name)
-		// newPrefix := fmt.Sprintf("%s@%s", lib.Name, lib.Version)
-		// versionedPath = strings.Replace(relPath, oldPrefix, newPrefix, 1)
 	} else {
 		// For unversioned packages, use path as-is
 		versionedPath = relPath

--- a/pkg/registry/gc.go
+++ b/pkg/registry/gc.go
@@ -1,0 +1,158 @@
+// Copyright 2018 The ksonnet authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package registry
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/ksonnet/ksonnet/pkg/pkg"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+// FsRemoveAller Subset of afero.Fs - just remove a directory
+type FsRemoveAller interface {
+	// RemoveAll removes a directory path and any children it contains. It
+	// does not fail if the path does not exist (return nil).
+	RemoveAll(path string) error
+}
+
+type vendorPathResolver interface {
+	InstalledChecker
+	VendorPath(pkg.Descriptor) (string, error)
+}
+
+// GarbageCollector removes vendored packages that are no longer needed
+type GarbageCollector struct {
+	pkgManager vendorPathResolver
+	fs         FsRemoveAller
+	root       string
+
+	removeEmptyParentsFn func(path string, root string) error
+}
+
+// NewGarbageCollector constructs a GarbageCollector
+func NewGarbageCollector(fs afero.Fs, pm vendorPathResolver, root string) GarbageCollector {
+	return GarbageCollector{
+		pkgManager: pm,
+		fs:         fs,
+		root:       root,
+
+		removeEmptyParentsFn: func(path string, root string) error {
+			return removeEmptyParents(fs, path, root)
+		},
+	}
+}
+
+// RemoveOrphans removes vendored packages that have been orphaned
+func (gc GarbageCollector) RemoveOrphans(d pkg.Descriptor) error {
+	log := log.WithField("action", "GarbageCollector.RemoveOrphans")
+	installed, err := gc.pkgManager.IsInstalled(d)
+	if err != nil {
+		return errors.Wrapf(err, "checking installed status: %v", d)
+	}
+	// Only remove orphans
+	if installed {
+		return nil
+	}
+
+	path, err := gc.pkgManager.VendorPath(d)
+	if err != nil {
+		return errors.Wrapf(err, "resolving path for descriptor: %v", d)
+	}
+
+	if path == "" {
+		return nil
+	}
+
+	if gc.fs == nil {
+		return errors.New("nil fs")
+	}
+	log.Debugf("removing path %s", path)
+	if err := gc.fs.RemoveAll(path); err != nil {
+		return errors.Wrapf(err, "removing path %s for package %v", path, d)
+	}
+
+	if gc.removeEmptyParentsFn == nil {
+		return nil
+	}
+	if err := gc.removeEmptyParentsFn(path, gc.root); err != nil {
+		return errors.Wrapf(err, "removing empty parents path %s", path)
+	}
+
+	return nil
+}
+
+// Returns true if the specified directory is empty
+func isDirEmpty(fs afero.Fs, path string) (bool, error) {
+	if fs == nil {
+		return false, errors.New("nil fs")
+	}
+	f, err := fs.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
+// Remove empty directories, up to the provided root, exclusive
+func removeEmptyParents(fs afero.Fs, path string, root string) error {
+	if fs == nil {
+		return errors.New("nil fs")
+	}
+
+	root = filepath.Clean(root)
+	path = filepath.Clean(filepath.Dir(path))
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return errors.Wrapf(err, "%s not subpath of %s", path, root)
+	}
+
+	// while path is a subpath of root...
+	for !strings.HasPrefix(rel, ".") {
+		if fi, err := fs.Stat(path); err != nil || !fi.IsDir() {
+			break
+		}
+
+		empty, err := isDirEmpty(fs, path)
+		if err != nil {
+			return errors.Wrapf(err, path)
+		}
+		if !empty {
+			break
+		}
+
+		if err := fs.Remove(path); err != nil {
+			return errors.Wrapf(err, path)
+		}
+
+		path = filepath.Dir(path)
+		rel, err = filepath.Rel(root, path)
+		if err != nil {
+			return errors.Wrapf(err, "%s not subpath of %s", path, root)
+		}
+	}
+
+	return nil
+}

--- a/pkg/registry/gc_test.go
+++ b/pkg/registry/gc_test.go
@@ -1,0 +1,191 @@
+// Copyright 2018 The ksonnet authors
+
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package registry
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ksonnet/ksonnet/pkg/pkg"
+	"github.com/ksonnet/ksonnet/pkg/util/test"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+type removeAllFn func(path string) error
+type fakeRemover struct {
+	removeAllFn removeAllFn
+}
+
+func (f fakeRemover) RemoveAll(path string) error {
+	return f.removeAllFn(path)
+}
+
+type fakeVendorPathResolver struct {
+	pathFn        func(d pkg.Descriptor) (string, error)
+	isInstalledFn func(d pkg.Descriptor) (bool, error)
+}
+
+func (f fakeVendorPathResolver) VendorPath(d pkg.Descriptor) (string, error) {
+	return f.pathFn(d)
+}
+
+func (f fakeVendorPathResolver) IsInstalled(d pkg.Descriptor) (bool, error) {
+	return f.isInstalledFn(d)
+}
+
+func makeVendorPathResolver(t *testing.T, desc pkg.Descriptor, isInstalled bool, path string) fakeVendorPathResolver {
+	return fakeVendorPathResolver{
+		pathFn: func(d pkg.Descriptor) (string, error) {
+			assert.Equal(t, desc, d)
+			return path, nil
+		},
+		isInstalledFn: func(d pkg.Descriptor) (bool, error) {
+			assert.Equal(t, desc, d)
+			return isInstalled, nil
+		},
+	}
+}
+
+func TestGarbageCollector_RemoveOrphans(t *testing.T) {
+	tests := []struct {
+		name             string
+		d                pkg.Descriptor
+		pkgPath          string
+		isInstalled      bool
+		expectCallRemove bool
+		wantErr          bool
+	}{
+		{
+			name: "should remove",
+			d: pkg.Descriptor{
+				Name:    "nginx",
+				Version: "1.2.3",
+			},
+			pkgPath:          "/app/vendor/nginx@1.2.3",
+			isInstalled:      false,
+			expectCallRemove: true,
+		},
+		{
+			name: "should not remove",
+			d: pkg.Descriptor{
+				Name:    "nginx",
+				Version: "1.2.3",
+			},
+			isInstalled:      false,
+			expectCallRemove: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var called bool
+			remover := fakeRemover{
+				removeAllFn: func(path string) error {
+					assert.Equal(t, tc.pkgPath, path)
+					called = true
+					return nil
+				},
+			}
+			finderChecker := makeVendorPathResolver(t, tc.d, tc.isInstalled, tc.pkgPath)
+			gc := GarbageCollector{
+				pkgManager: finderChecker,
+				fs:         remover,
+			}
+			if err := gc.RemoveOrphans(tc.d); (err != nil) != tc.wantErr {
+				t.Errorf("GarbageCollector.RemoveOrphans() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			assert.Equal(t, tc.expectCallRemove, called)
+		})
+	}
+}
+
+func Test_removeEmptyParents(t *testing.T) {
+	tests := []struct {
+		name        string
+		stagePaths  []string
+		root        string
+		path        string
+		expectPaths []string
+		expectErr   bool
+	}{
+		{
+			name: "parent not empty",
+			root: "/app/vendor",
+			path: "/app/vendor/incubator/nginx@1.2.3",
+			stagePaths: []string{
+				"/app/vendor/incubator/mysql@4.5.6",
+			},
+			expectPaths: []string{
+				"/app/vendor/incubator/mysql@4.5.6",
+			},
+		},
+		{
+			name: "parent empty",
+			root: "/app/vendor",
+			path: "/app/vendor/incubator/nginx@1.2.3",
+			stagePaths: []string{
+				"/app/vendor/incubator",
+			},
+			expectPaths: []string{
+				"/app/vendor",
+			},
+		},
+		{
+			name: "grandparent not empty",
+			root: "/app/vendor",
+			path: "/app/vendor/helm-stable/mysql/helm/0.9.3/mysql",
+			stagePaths: []string{
+				"/app/vendor/helm-stable/mysql/helm/0.9.3",
+				"/app/vendor/helm-stable/nginx/helm/1.2.3",
+			},
+			expectPaths: []string{
+				"/app/vendor/helm-stable/nginx/helm/1.2.3",
+			},
+		},
+		{
+			name: "grandparent empty",
+			root: "/app/vendor",
+			path: "/app/vendor/helm-stable/mysql/helm/0.9.3/mysql",
+			stagePaths: []string{
+				"/app/vendor/helm-stable/mysql/helm/0.9.3",
+			},
+			expectPaths: []string{
+				"/app/vendor",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			for _, path := range tc.stagePaths {
+				fs.MkdirAll(path, os.FileMode(0755))
+			}
+
+			err := removeEmptyParents(fs, tc.path, tc.root)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("GarbageCollector.removeEmptyParents() error = %v, wantErr %v", err, tc.expectErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			test.AssertExpectedPaths(t, fs, tc.root, tc.expectPaths)
+		})
+	}
+}

--- a/pkg/registry/mocks/PackageManager.go
+++ b/pkg/registry/mocks/PackageManager.go
@@ -27,11 +27,11 @@ type PackageManager struct {
 }
 
 // Find provides a mock function with given fields: _a0
-func (_m *PackageManager) Find(_a0 string) (pkg.Package, error) {
+func (_m *PackageManager) Find(_a0 pkg.Descriptor) (pkg.Package, error) {
 	ret := _m.Called(_a0)
 
 	var r0 pkg.Package
-	if rf, ok := ret.Get(0).(func(string) pkg.Package); ok {
+	if rf, ok := ret.Get(0).(func(pkg.Descriptor) pkg.Package); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
@@ -40,7 +40,7 @@ func (_m *PackageManager) Find(_a0 string) (pkg.Package, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
+	if rf, ok := ret.Get(1).(func(pkg.Descriptor) error); ok {
 		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
@@ -178,6 +178,27 @@ func (_m *PackageManager) RemotePackages() ([]pkg.Package, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func() error); ok {
 		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// VendorPath provides a mock function with given fields: _a0
+func (_m *PackageManager) VendorPath(_a0 pkg.Descriptor) (string, error) {
+	ret := _m.Called(_a0)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(pkg.Descriptor) string); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(pkg.Descriptor) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/registry/package_manager_test.go
+++ b/pkg/registry/package_manager_test.go
@@ -206,7 +206,10 @@ func Test_packageManager_Find(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			p, err := pm.Find(tc.name)
+			d, err := pkg.Parse(tc.name)
+			require.NoError(t, err)
+
+			p, err := pm.Find(d)
 			if tc.expectErr {
 				require.Error(t, err, tc.name)
 				continue


### PR DESCRIPTION
Packages are candidates for removal when they are no longer referenced by either a specific environment or the global scope.

Closes #624

Signed-off-by: Oren Shomron <shomron@gmail.com>