### PR TITLE
Changed old library references to packages; tls-skip-verify to docs

### DIFF
--- a/docs/cli-reference/ks.md
+++ b/docs/cli-reference/ks.md
@@ -19,6 +19,7 @@ ks [flags]
 
 ```
   -h, --help                 help for ks
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_apply.md
+++ b/docs/cli-reference/ks_apply.md
@@ -96,6 +96,7 @@ ks apply dev -c guestbook-ui -c nginx-depl --create false
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_component.md
+++ b/docs/cli-reference/ks_component.md
@@ -19,6 +19,7 @@ ks component [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_component_list.md
+++ b/docs/cli-reference/ks_component_list.md
@@ -33,6 +33,7 @@ ks component list
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_component_rm.md
+++ b/docs/cli-reference/ks_component_rm.md
@@ -29,6 +29,7 @@ ks component list
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_delete.md
+++ b/docs/cli-reference/ks_delete.md
@@ -72,6 +72,7 @@ ks delete --kubeconfig=./kubeconfig -c nginx
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_diff.md
+++ b/docs/cli-reference/ks_diff.md
@@ -94,6 +94,7 @@ ks diff dev -c redis
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env.md
+++ b/docs/cli-reference/ks_env.md
@@ -46,6 +46,7 @@ ks env [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_add.md
+++ b/docs/cli-reference/ks_env_add.md
@@ -89,6 +89,7 @@ ks env add prod --server=https://ksonnet-1.us-west.elb.amazonaws.com
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_current.md
+++ b/docs/cli-reference/ks_env_current.md
@@ -42,6 +42,7 @@ ks env current --unset
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_describe.md
+++ b/docs/cli-reference/ks_env_describe.md
@@ -19,6 +19,7 @@ ks env describe <env> [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_list.md
+++ b/docs/cli-reference/ks_env_list.md
@@ -32,6 +32,7 @@ ks env list [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_rm.md
+++ b/docs/cli-reference/ks_env_rm.md
@@ -45,6 +45,7 @@ ks env rm us-west/staging
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_set.md
+++ b/docs/cli-reference/ks_env_set.md
@@ -50,6 +50,7 @@ ks env set us-west/staging --server=https://192.168.99.100:8443
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_targets.md
+++ b/docs/cli-reference/ks_env_targets.md
@@ -20,6 +20,7 @@ ks env targets [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_env_update.md
+++ b/docs/cli-reference/ks_env_update.md
@@ -5,7 +5,7 @@ Updates the libs for an environment
 ### Synopsis
 
 
-The `update` command updates libraries for an environment.
+The `update` command updates packages for an environment.
 
 ### Related Commands
 
@@ -25,7 +25,7 @@ ks env update <env-name> [flags]
 
 ```
 
-# Update the environment 'us-west/staging' libs.
+# Update the environment 'us-west/staging' packages.
 ks env update us-west/staging
 ```
 
@@ -38,6 +38,7 @@ ks env update us-west/staging
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_generate.md
+++ b/docs/cli-reference/ks_generate.md
@@ -82,6 +82,7 @@ ks prototype use single-port-deployment nginx-depl \
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_import.md
+++ b/docs/cli-reference/ks_import.md
@@ -21,6 +21,7 @@ ks import [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_init.md
+++ b/docs/cli-reference/ks_init.md
@@ -107,6 +107,7 @@ ks init app-name --dir=custom-location
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_module.md
+++ b/docs/cli-reference/ks_module.md
@@ -15,6 +15,7 @@ Manage ksonnet modules
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_module_create.md
+++ b/docs/cli-reference/ks_module_create.md
@@ -19,6 +19,7 @@ ks module create <name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_module_list.md
+++ b/docs/cli-reference/ks_module_list.md
@@ -21,6 +21,7 @@ ks module list [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_param.md
+++ b/docs/cli-reference/ks_param.md
@@ -43,6 +43,7 @@ Jsonnet files.
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_param_delete.md
+++ b/docs/cli-reference/ks_param_delete.md
@@ -41,6 +41,7 @@ ks param delete guestbook replicas --env=dev
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_param_diff.md
+++ b/docs/cli-reference/ks_param_diff.md
@@ -46,6 +46,7 @@ ks param diff dev prod --component=guestbook
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_param_list.md
+++ b/docs/cli-reference/ks_param_list.md
@@ -52,6 +52,7 @@ ks param list guestbook --env=dev
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_param_set.md
+++ b/docs/cli-reference/ks_param_set.md
@@ -52,6 +52,7 @@ ks param set guestbook replicas 2 --env=dev
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_pkg.md
+++ b/docs/cli-reference/ks_pkg.md
@@ -40,6 +40,7 @@ See the annotated file tree below, as an example:
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 
@@ -49,4 +50,5 @@ See the annotated file tree below, as an example:
 * [ks pkg describe](ks_pkg_describe.md)	 - Describe a ksonnet package and its contents
 * [ks pkg install](ks_pkg_install.md)	 - Install a package (e.g. extra prototypes) for the current ksonnet app
 * [ks pkg list](ks_pkg_list.md)	 - List all packages known (downloaded or not) for the current ksonnet app
+* [ks pkg remove](ks_pkg_remove.md)	 - Remove a package from the app or environment scope
 

--- a/docs/cli-reference/ks_pkg_describe.md
+++ b/docs/cli-reference/ks_pkg_describe.md
@@ -9,9 +9,9 @@ The `describe` command outputs documentation for a package that is available
 (e.g. downloaded) in the current ksonnet application. (This must belong to an already
 known `<registry-name>` like *incubator*). The output includes:
 
-1. The library name
-2. A brief description provided by the library authors
-3. A list of available prototypes provided by the library
+1. The package name
+2. A brief description provided by the package authors
+3. A list of available prototypes provided by the package
 
 ### Related Commands
 
@@ -35,6 +35,7 @@ ks pkg describe [<registry-name>/]<package-name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_pkg_install.md
+++ b/docs/cli-reference/ks_pkg_install.md
@@ -5,13 +5,13 @@ Install a package (e.g. extra prototypes) for the current ksonnet app
 ### Synopsis
 
 
-The `install` command caches a ksonnet library locally, and makes it available
+The `install` command caches a ksonnet package locally, and makes it available
 for use in the current ksonnet application. Enough info and metadata is recorded in
 `app.yaml` that new users can retrieve the dependency after a fresh clone of this app.
 
-The library itself needs to be located in a registry (e.g. Github repo). By default,
+The package itself needs to be located in a registry (e.g. Github repo). By default,
 ksonnet knows about two registries: *incubator* and *stable*, which are the release
-channels for official ksonnet libraries.
+channels for official ksonnet packages.
 
 ### Related Commands
 
@@ -23,7 +23,7 @@ channels for official ksonnet libraries.
 
 
 ```
-ks pkg install <registry>/<library>@<version> [flags]
+ks pkg install <registry>/<package>@<version> [flags]
 ```
 
 ### Examples
@@ -59,6 +59,7 @@ ks pkg install --env stage incubator/nginx@40285d8a14f1ac5787e405e1023cf0c07f6aa
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_pkg_list.md
+++ b/docs/cli-reference/ks_pkg_list.md
@@ -37,6 +37,7 @@ ks pkg list [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_pkg_remove.md
+++ b/docs/cli-reference/ks_pkg_remove.md
@@ -1,0 +1,48 @@
+## ks pkg remove
+
+Remove a package from the app or environment scope
+
+### Synopsis
+
+
+The `remove` command removes a reference to a ksonnet library.  The reference can either be
+global or scoped to an environment. If the last reference to a library version is removed, the cached
+files will be removed as well.
+
+### Syntax
+
+
+```
+ks pkg remove <registry>/<library> [flags]
+```
+
+### Examples
+
+```
+
+# Remove an nginx dependency
+ks pkg remove incubator/nginx
+
+# Remove an nginx dependency from the stage environment
+ks pkg remove incubator/nginx --env stage
+
+```
+
+### Options
+
+```
+      --env string   Environment to remove package from (optional)
+  -h, --help         help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --tls-skip-verify      Skip verification of TLS server certificates
+  -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
+```
+
+### SEE ALSO
+
+* [ks pkg](ks_pkg.md)	 - Manage packages and dependencies for the current ksonnet application
+

--- a/docs/cli-reference/ks_prototype.md
+++ b/docs/cli-reference/ks_prototype.md
@@ -30,6 +30,7 @@ for your use case.
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_prototype_describe.md
+++ b/docs/cli-reference/ks_prototype_describe.md
@@ -42,6 +42,7 @@ ks prototype describe deployment
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_prototype_list.md
+++ b/docs/cli-reference/ks_prototype_list.md
@@ -37,6 +37,7 @@ ks prototype list [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_prototype_preview.md
+++ b/docs/cli-reference/ks_prototype_preview.md
@@ -58,6 +58,7 @@ Where 'ks-values' is a jsonnet file with the contents:
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_prototype_search.md
+++ b/docs/cli-reference/ks_prototype_search.md
@@ -38,6 +38,7 @@ ks prototype search service
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_prototype_use.md
+++ b/docs/cli-reference/ks_prototype_use.md
@@ -82,6 +82,7 @@ ks prototype use single-port-deployment nginx-depl \
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_registry.md
+++ b/docs/cli-reference/ks_registry.md
@@ -31,6 +31,7 @@ described above. (See `ks prototype --help` for more information.)
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_registry_add.md
+++ b/docs/cli-reference/ks_registry_add.md
@@ -59,6 +59,7 @@ ks registry add helm-stable https://kubernetes-charts.storage.googleapis.com
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_registry_describe.md
+++ b/docs/cli-reference/ks_registry_describe.md
@@ -32,6 +32,7 @@ ks registry describe <registry-name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_registry_list.md
+++ b/docs/cli-reference/ks_registry_list.md
@@ -33,6 +33,7 @@ ks registry list [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_registry_set.md
+++ b/docs/cli-reference/ks_registry_set.md
@@ -34,6 +34,7 @@ ks registry set [registry-name] [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_show.md
+++ b/docs/cli-reference/ks_show.md
@@ -62,6 +62,7 @@ ks show dev -c redis -c nginx-server
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_upgrade.md
+++ b/docs/cli-reference/ks_upgrade.md
@@ -38,6 +38,7 @@ ks upgrade
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_validate.md
+++ b/docs/cli-reference/ks_validate.md
@@ -76,6 +76,7 @@ ksonnet validate prod -c redis
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/cli-reference/ks_version.md
+++ b/docs/cli-reference/ks_version.md
@@ -24,6 +24,7 @@ ks version [flags]
 ### Options inherited from parent commands
 
 ```
+      --tls-skip-verify      Skip verification of TLS server certificates
   -v, --verbose count[=-1]   Increase verbosity. May be given multiple times.
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -24,7 +24,7 @@ The following diagram shows how the ksonnet framework works holistically:
 ksonnet's package management schema can be summed up as follows:
 
 *registry* > *package* > *prototype*<br>
-**Ex:** [`incubator` repo](https://github.com/ksonnet/parts/tree/master/incubator) > [Redis library](https://github.com/ksonnet/parts/tree/master/incubator/redis) > [`redis-stateless` prototype](https://github.com/ksonnet/parts/blob/master/incubator/redis/prototypes/redis-stateless.jsonnet)
+**Ex:** [`incubator` repo](https://github.com/ksonnet/parts/tree/master/incubator) > [Redis package](https://github.com/ksonnet/parts/tree/master/incubator/redis) > [`redis-stateless` prototype](https://github.com/ksonnet/parts/blob/master/incubator/redis/prototypes/redis-stateless.jsonnet)
 
 ---
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -25,5 +25,5 @@ libraries:
     path: scheduling
 ```
 
-In this example, the registry contains a single library, `scheduling`, which lives in directory `scheduling`. This path is relative to the directory that contains `registry.yaml`. 
+In this example, the registry contains a single package, `scheduling`, which lives in directory `scheduling`. This path is relative to the directory that contains `registry.yaml`.
 

--- a/pkg/clicmd/env_update.go
+++ b/pkg/clicmd/env_update.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	envUpdateLong = `
-The ` + "`update`" + ` command updates libraries for an environment.
+The ` + "`update`" + ` command updates packages for an environment.
 
 ### Related Commands
 
@@ -38,7 +38,7 @@ The ` + "`update`" + ` command updates libraries for an environment.
 ### Syntax
 `
 	envUpdateExample = `
-# Update the environment 'us-west/staging' libs.
+# Update the environment 'us-west/staging' packages.
 ks env update us-west/staging`
 )
 

--- a/pkg/clicmd/pkg_describe.go
+++ b/pkg/clicmd/pkg_describe.go
@@ -30,9 +30,9 @@ The ` + "`describe`" + ` command outputs documentation for a package that is ava
 (e.g. downloaded) in the current ksonnet application. (This must belong to an already
 known ` + "`<registry-name>`" + ` like *incubator*). The output includes:
 
-1. The library name
-2. A brief description provided by the library authors
-3. A list of available prototypes provided by the library
+1. The package name
+2. A brief description provided by the package authors
+3. A list of available prototypes provided by the package
 
 ### Related Commands
 

--- a/pkg/clicmd/pkg_install.go
+++ b/pkg/clicmd/pkg_install.go
@@ -31,13 +31,13 @@ var (
 	vPkgInstallForce = "pkg-install-force"
 
 	pkgInstallLong = `
-The ` + "`install`" + ` command caches a ksonnet library locally, and makes it available
+The ` + "`install`" + ` command caches a ksonnet package locally, and makes it available
 for use in the current ksonnet application. Enough info and metadata is recorded in
 ` + "`app.yaml` " + `that new users can retrieve the dependency after a fresh clone of this app.
 
-The library itself needs to be located in a registry (e.g. Github repo). By default,
+The package itself needs to be located in a registry (e.g. Github repo). By default,
 ksonnet knows about two registries: *incubator* and *stable*, which are the release
-channels for official ksonnet libraries.
+channels for official ksonnet packages.
 
 ### Related Commands
 
@@ -68,14 +68,14 @@ ks pkg install --env stage incubator/nginx@40285d8a14f1ac5787e405e1023cf0c07f6aa
 func newPkgInstallCmd(a app.App) *cobra.Command {
 
 	pkgInstallCmd := &cobra.Command{
-		Use:     "install <registry>/<library>@<version>",
+		Use:     "install <registry>/<package>@<version>",
 		Short:   pkgShortDesc["install"],
 		Long:    pkgInstallLong,
 		Example: pkgInstallExample,
 		Aliases: []string{"get"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("Command requires a single argument of the form <registry>/<library>@<version>\n\n%s", cmd.UsageString())
+				return fmt.Errorf("Command requires a single argument of the form <registry>/<package>@<version>\n\n%s", cmd.UsageString())
 			}
 
 			m := map[string]interface{}{


### PR DESCRIPTION
Closes #103 

Library should only refer to a libsonnet file or the remaining instance in `registry.yaml`

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>