### PR TITLE
Changed default module for import to /

### DIFF
--- a/pkg/actions/import_test.go
+++ b/pkg/actions/import_test.go
@@ -53,7 +53,7 @@ func TestImport_http(t *testing.T) {
 
 		in := map[string]interface{}{
 			OptionApp:    appMock,
-			OptionModule: "",
+			OptionModule: "/",
 			OptionPath:   ts.URL,
 		}
 

--- a/pkg/clicmd/import.go
+++ b/pkg/clicmd/import.go
@@ -49,7 +49,7 @@ func newImportCmd(a app.App) *cobra.Command {
 
 	importCmd.Flags().StringP(flagFilename, shortFilename, "", "Filename, directory, or URL for component to import")
 	viper.BindPFlag(vImportFilename, importCmd.Flags().Lookup(flagFilename))
-	importCmd.Flags().String(flagModule, "", "Component module")
+	importCmd.Flags().String(flagModule, "/", "Component module")
 	viper.BindPFlag(vImportModule, importCmd.Flags().Lookup(flagModule))
 
 	return importCmd

--- a/pkg/clicmd/import_test.go
+++ b/pkg/clicmd/import_test.go
@@ -24,12 +24,13 @@ import (
 func Test_importCmd(t *testing.T) {
 	cases := []cmdTestCase{
 		{
-			name:   "import location",
+			name:   "import location without module",
 			args:   []string{"import", "-f", "location"},
 			action: actionImport,
 			expected: map[string]interface{}{
-				actions.OptionApp:  nil,
-				actions.OptionPath: "location",
+				actions.OptionApp:    nil,
+				actions.OptionPath:   "location",
+				actions.OptionModule: "/",
 			},
 		},
 		{


### PR DESCRIPTION
Closes #807 

`ks import -f config.yaml` will use `--module /` by default

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>