### PR TITLE
Fix sourcePath for imported json on root module

### DIFF
--- a/pkg/actions/import.go
+++ b/pkg/actions/import.go
@@ -271,9 +271,6 @@ func (i *Import) createComponentFromData(name, data string, templateType prototy
 
 func (i *Import) createComponent(fileName, base, ext string, templateType prototype.TemplateType) error {
 	var name bytes.Buffer
-	if i.module != "" {
-		name.WriteString(i.module + "/")
-	}
 
 	name.WriteString(strings.TrimSuffix(base, ext))
 

--- a/pkg/actions/testdata/import/my-service.json
+++ b/pkg/actions/testdata/import/my-service.json
@@ -1,0 +1,19 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "my-service"
+  },
+  "spec": {
+    "selector": {
+      "app": "MyApp"
+    },
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 9376
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR removes the extra `/` added because the default module is `/` since 0.11

Added test to hit the code path on https://github.com/ksonnet/ksonnet/blob/master/pkg/actions/import.go#L203

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>