### PR TITLE
Fix panic during ksonnet-lib generate - when parameters exist after body parameter in cluster OpenAPI spec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -598,7 +598,7 @@
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
-  digest = "1:940f9581e8a768010b6dada7055bc86bd872f7f64e7affe894f39115956073c2"
+  digest = "1:26096952c000895a6b908d301f07d68b9a39a9ba57bd447f99edf3db9f47c4a9"
   name = "github.com/ksonnet/ksonnet-lib"
   packages = [
     "ksonnet-gen/astext",
@@ -610,8 +610,8 @@
     "ksonnet-gen/printer",
   ]
   pruneopts = "UT"
-  revision = "ed0796f3cb97ebc35ae54f543b1814a7c8dae305"
-  version = "v0.1.11"
+  revision = "d03da231d6c8bd74437b74a1e9e8b966f13dffa2"
+  version = "v0.1.12"
 
 [[projects]]
   digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = ["k8s.io/kubernetes/pkg/kubectl/cmd/util"]
 
 [[constraint]]
   name = "github.com/ksonnet/ksonnet-lib"
-  version = "v0.1.11"
+  version = "v0.1.12"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/paths.go
+++ b/vendor/github.com/ksonnet/ksonnet-lib/ksonnet-gen/ksonnet/paths.go
@@ -19,17 +19,23 @@ func parsePaths(apiSpec *spec.Swagger) (map[string]Component, error) {
 				continue
 			}
 
-			var body *spec.Parameter
+			var body spec.Parameter
+			var hasBody bool
 			for _, param := range verb.Parameters {
 				if param.Name == "body" {
-					body = &param
+					body = param // shallow copy
+					hasBody = true
+					break
 				}
 			}
 
-			if body == nil {
+			if !hasBody {
 				continue
 			}
 
+			if body.Schema == nil {
+				return nil, errors.Errorf("invalid body parameter - missing required field: schema")
+			}
 			ref := extractRef(*body.Schema)
 
 			component, exists, err := pathExtensionComponent(verb.Extensions)


### PR DESCRIPTION
Incorporates ksonnet/ksonnet-lib#155

Fixes #883

Signed-off-by: Oren Shomron <shomron@gmail.com>