### PR TITLE
add ppc64le and s390x support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
       - windows
     goarch:
       - amd64
+      - ppc64le
+      - s390x
 archive:
   wrap_in_directory: true
   format_overrides:


### PR DESCRIPTION
closes: https://github.com/ksonnet/ksonnet/issues/885

Tested cross build with following go version:

```
go version go1.10.5 linux/amd64
```

Manually copy the binary to ppc64le and s390x machine, ks works fine.

* ppc64le

```
root@cfcp02:~/ks_0.13.1_linux_ppc64le# cat /etc/os-release
NAME="Ubuntu"
VERSION="16.04.4 LTS (Xenial Xerus)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 16.04.4 LTS"
VERSION_ID="16.04"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
VERSION_CODENAME=xenial
UBUNTU_CODENAME=xenial
root@cfcp02:~/ks_0.13.1_linux_ppc64le# uname -a
Linux cfcp02 4.10.0-37-generic #41~16.04.1-Ubuntu SMP Fri Oct 6 22:44:24 UTC 2017 ppc64le ppc64le ppc64le GNU/Linux
```

* s390x

```
root@platcon3:~/ks_0.13.1_linux_s390x# cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
root@platcon3:~/ks_0.13.1_linux_s390x# uname -a
Linux platcon3 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:42:24 UTC 2018 s390x s390x s390x GNU/Linux
```