### PR TITLE
Prevent resource patching when applying in dry-run mode

### DIFF
--- a/pkg/cluster/apply.go
+++ b/pkg/cluster/apply.go
@@ -92,7 +92,7 @@ func RunApply(config ApplyConfig, opts ...ApplyOpts) error {
 		objectInfo:            &objectInfo{},
 		ksonnetObjectFactory: func() ksonnetObject {
 			factory := cmdutil.NewFactory(config.ClientConfig.Config)
-			return newDefaultKsonnetObject(factory)
+			return newDefaultKsonnetObject(factory, config.DryRun)
 		},
 		conflictTimeout: 1 * time.Second,
 	}

--- a/pkg/cluster/ksonnet_object.go
+++ b/pkg/cluster/ksonnet_object.go
@@ -34,8 +34,8 @@ type defaultKsonnetObject struct {
 
 var _ ksonnetObject = (*defaultKsonnetObject)(nil)
 
-func newDefaultKsonnetObject(factory cmdutil.Factory) *defaultKsonnetObject {
-	merger := newDefaultObjectMerger(factory)
+func newDefaultKsonnetObject(factory cmdutil.Factory, dryRun bool) *defaultKsonnetObject {
+	merger := newDefaultObjectMerger(factory, dryRun)
 
 	return &defaultKsonnetObject{
 		objectMerger: merger,

--- a/pkg/cluster/ksonnet_object_test.go
+++ b/pkg/cluster/ksonnet_object_test.go
@@ -53,6 +53,7 @@ func Test_defaultKsonnetObject_MergeFromCluster(t *testing.T) {
 		expected     *unstructured.Unstructured
 		objectMerger *fakeObjectMerger
 		isErr        bool
+		dryRun       bool
 	}{
 		{
 			name: "merge object",
@@ -78,6 +79,15 @@ func Test_defaultKsonnetObject_MergeFromCluster(t *testing.T) {
 			},
 			expected: sampleObj,
 		},
+		{
+			name: "dry run",
+			obj:  sampleObj,
+			objectMerger: &fakeObjectMerger{
+				mergeObj: sampleObj,
+			},
+			expected: sampleObj,
+			dryRun:   true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -87,7 +97,7 @@ func Test_defaultKsonnetObject_MergeFromCluster(t *testing.T) {
 
 			co := Clients{}
 
-			ko := newDefaultKsonnetObject(factory)
+			ko := newDefaultKsonnetObject(factory, tc.dryRun)
 			ko.objectMerger = tc.objectMerger
 
 			merged, err := ko.MergeFromCluster(co, tc.obj)

--- a/pkg/cluster/upsert.go
+++ b/pkg/cluster/upsert.go
@@ -107,6 +107,7 @@ func (u *defaultUpserter) updateObject(rc ResourceClient, obj *unstructured.Unst
 	}
 
 	if u.DryRun {
+		log.Info("skipping patch (dry-run)")
 		return obj, nil
 	}
 


### PR DESCRIPTION
Fixes #615

Signed-off-by: Oren Shomron <shomron@gmail.com>

---

## Before fix

```
$ k create -f kuard.yaml
pod/kuard created
$ k get -o yaml pod/kuard | yq .metadata.labels
null
$ ks apply --dry-run default
INFO tagging ksonnet managed object (dry-run)
INFO upserting object (dry-run)
$ k get -o yaml pod/kuard | yq .metadata.labels
{
  "ksonnet.io/component": "kuard"
}
```

## After fix

```
$ k delete -f kuard.yaml
pod "kuard" deleted
$ k create -f kuard.yaml
pod/kuard created
$ k get -o yaml pod/kuard | yq .metadata.labels
null
$ ksdev apply --dry-run default
INFO tagging ksonnet managed object (dry-run)
INFO upserting object (dry-run)
$ k get -o yaml pod/kuard | yq .metadata.labels
null
```